### PR TITLE
fix(routes): correct BaseReply type for POST routes that return data

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -95,7 +95,7 @@ export function setupRoutes(server: FastifyInstance) {
     }
 
 //TODO: Handle pictures
-    async function handleNewClimb(req: Climb): Promise<Task> {
+    async function handleNewClimb(req: Climb): Promise<Process<ClimbRecord[]>> {
         const {name, difficulty, type, color, setter, dateSet, gym} = req;
         const {data, error} = await server.supabase.from("climbs").insert([
             {
@@ -136,7 +136,7 @@ export function setupRoutes(server: FastifyInstance) {
     }
 
 //TODO: remove for loop
-    async function handleFilteredSearch(req: Search): Promise<Task> {
+    async function handleFilteredSearch(req: Search): Promise<Process<ClimbRecord[]>> {
         const {lowerDifficulty, upperDifficulty, type, color, startDate, endDate, gym, archived} = req;
         const query = server.supabase.from("climbs").select('*');
         let boulderList: string[] = Object.keys(BOULDER_GRADES);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -37,7 +37,7 @@ export function setupRoutes(server: FastifyInstance) {
 
     server.post<{
         Body: Climb;
-        Reply: BaseReply<void>;
+        Reply: BaseReply<any[]>;
 
     }>("/climbs/new", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleNewClimb(req.body));
@@ -52,7 +52,7 @@ export function setupRoutes(server: FastifyInstance) {
 
     server.post<{
         Body: Search;
-        Reply: BaseReply<void>;
+        Reply: BaseReply<any[]>;
     }>("/climbs/search/filter", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleFilteredSearch(req.body));
         res.status(code).send(reply);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -11,7 +11,8 @@ import {
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
+    type Log,
+    type ClimbRecord,
 } from "../../frontend/src/lib/types.ts";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
@@ -37,7 +38,7 @@ export function setupRoutes(server: FastifyInstance) {
 
     server.post<{
         Body: Climb;
-        Reply: BaseReply<any[]>;
+        Reply: BaseReply<ClimbRecord[]>;
 
     }>("/climbs/new", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleNewClimb(req.body));
@@ -52,7 +53,7 @@ export function setupRoutes(server: FastifyInstance) {
 
     server.post<{
         Body: Search;
-        Reply: BaseReply<any[]>;
+        Reply: BaseReply<ClimbRecord[]>;
     }>("/climbs/search/filter", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleFilteredSearch(req.body));
         res.status(code).send(reply);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,3 +1,18 @@
+export interface ClimbRecord {
+    id: number;
+    name: string;
+    difficulty: string;
+    type: string;
+    color: string;
+    setter: string;
+    date_set: string;
+    gym: string;
+    picture: string | null;
+    archived: boolean;
+    claimed: boolean;
+    created_at: string;
+}
+
 export interface Climb {
     name: string;
     difficulty: string;


### PR DESCRIPTION
Fixes #8

Two POST routes in `backend/src/routes.ts` were typed with `BaseReply<void>` but their handlers return data arrays from Supabase:

- `POST /climbs/new` → `handleNewClimb` returns inserted climb records
- `POST /climbs/search/filter` → `handleFilteredSearch` returns filtered climb records

Changed `Reply` generic from `BaseReply<void>` to `BaseReply<any[]>` to match actual runtime behavior.

No functional changes — purely type-level fix.