### PR TITLE
feat: custom PWA install prompt with dismissable banner

### DIFF
--- a/frontend/src/components/InstallPrompt.tsx
+++ b/frontend/src/components/InstallPrompt.tsx
@@ -1,0 +1,82 @@
+import {useEffect, useState} from "react";
+import "../pages/styles/installprompt.css";
+
+interface BeforeInstallPromptEvent extends Event {
+    readonly platforms: string[];
+    readonly userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+    prompt(): Promise<void>;
+}
+
+const STORAGE_KEY = "clapp:install-prompt-dismissed";
+
+function isStandalone(): boolean {
+    if (typeof window === "undefined") return false;
+    const mql = window.matchMedia?.("(display-mode: standalone)");
+    const iosStandalone = (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+    return Boolean(mql?.matches) || iosStandalone;
+}
+
+export default function InstallPrompt() {
+    const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        if (isStandalone()) return;
+        if (localStorage.getItem(STORAGE_KEY) === "1") return;
+
+        const onBeforeInstallPrompt = (event: Event) => {
+            event.preventDefault();
+            setDeferredPrompt(event as BeforeInstallPromptEvent);
+            setVisible(true);
+        };
+
+        const onAppInstalled = () => {
+            setVisible(false);
+            setDeferredPrompt(null);
+            localStorage.setItem(STORAGE_KEY, "1");
+        };
+
+        window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+        window.addEventListener("appinstalled", onAppInstalled);
+
+        return () => {
+            window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+            window.removeEventListener("appinstalled", onAppInstalled);
+        };
+    }, []);
+
+    const dismiss = () => {
+        localStorage.setItem(STORAGE_KEY, "1");
+        setVisible(false);
+    };
+
+    const install = async () => {
+        if (!deferredPrompt) return;
+        await deferredPrompt.prompt();
+        const { outcome } = await deferredPrompt.userChoice;
+        if (outcome === "accepted" || outcome === "dismissed") {
+            localStorage.setItem(STORAGE_KEY, "1");
+        }
+        setDeferredPrompt(null);
+        setVisible(false);
+    };
+
+    if (!visible || !deferredPrompt) return null;
+
+    return (
+        <div className={"install-prompt"} role={"dialog"} aria-live={"polite"}>
+            <div className={"install-prompt-text"}>
+                <strong>Install Clapp</strong>
+                <span>Add the app to your home screen for a faster, fullscreen climbing experience.</span>
+            </div>
+            <div className={"install-prompt-actions"}>
+                <button className={"install-prompt-install"} onClick={install} type={"button"}>
+                    Install
+                </button>
+                <button className={"install-prompt-dismiss"} onClick={dismiss} type={"button"} aria-label={"Dismiss install prompt"}>
+                    Not now
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -5,6 +5,7 @@ import type {Session} from "@supabase/supabase-js";
 import { supabaseClient} from "../util/supabaseClient.ts";
 import LoginPage from "./login.tsx";
 import ProtectedRoute from "./../components/ProtectedRoute";
+import InstallPrompt from "../components/InstallPrompt.tsx";
 
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
@@ -57,6 +58,7 @@ function Root() {
                 }
             />
         </Routes>
+        <InstallPrompt/>
     </BrowserRouter>);
 
 }

--- a/frontend/src/pages/styles/installprompt.css
+++ b/frontend/src/pages/styles/installprompt.css
@@ -1,0 +1,62 @@
+.install-prompt {
+    position: fixed;
+    left: 16px;
+    right: 16px;
+    bottom: 144px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px 16px;
+    border-radius: 16px;
+    background-color: #EDCDB7;
+    border: 2px solid black;
+    z-index: 5;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+}
+
+.install-prompt-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 14px;
+    line-height: 1.3;
+}
+
+.install-prompt-text strong {
+    font-size: 16px;
+}
+
+.install-prompt-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.install-prompt-install {
+    padding: 8px 16px;
+    border-radius: 20px;
+    border: 2px solid black;
+    background-color: #B7D7ED;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.install-prompt-dismiss {
+    padding: 8px 12px;
+    border-radius: 20px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+@media only screen and (min-width: 768px) {
+    .install-prompt {
+        left: auto;
+        right: 24px;
+        bottom: 24px;
+        max-width: 420px;
+    }
+}


### PR DESCRIPTION
## Summary

Wires up a custom **Install App** prompt for the existing `vite-plugin-pwa` setup. Previously the project registered a service worker + manifest but never surfaced install UI to users; browsers either showed their generic mini-infobar or nothing at all. This PR adds a dismissable in-app banner that fires once per user and properly handles the `beforeinstallprompt` / `appinstalled` lifecycle.

## What changed

- **New component** `frontend/src/components/InstallPrompt.tsx`
  - Listens for `beforeinstallprompt`, calls `event.preventDefault()`, stashes the event as `deferredPrompt`, and renders a banner.
  - Install button calls `deferredPrompt.prompt()` and awaits `userChoice`. Whether the user accepts or dismisses, we persist `clapp:install-prompt-dismissed=1` in `localStorage` so the banner never re-prompts on this device.
  - "Not now" button also sets the localStorage flag and hides the banner.
  - Listens for the `appinstalled` event to auto-hide if install happens through the browser's own UI.
  - Short-circuits early if the app is already running standalone (either `display-mode: standalone` or iOS `navigator.standalone`) so we don't nag users who already installed.
- **New stylesheet** `frontend/src/pages/styles/installprompt.css` following the existing plain-CSS pattern in `frontend/src/pages/styles/` (the project declares `tailwindcss` as a dep but no component actually uses it; I matched the existing color palette — `#EDCDB7` bg, 2px black border, rounded pill buttons — used by `.log-button`).
- **Wired into `frontend/src/pages/main.tsx`** — rendered inside `<BrowserRouter>` outside `<Routes>` so the banner is available on both the login page and authenticated pages. Positioned above the bottom nav (`home-row`) on mobile, bottom-right on desktop via the 768px breakpoint already used throughout the app.

## Assumptions

- "Once per user" = **once per device**, using `localStorage`. The user model doesn't store client preferences and there's no backend endpoint for UI dismissals, so syncing across devices would require schema + routes that are out of scope for this PR. If you'd prefer per-account persistence, happy to add a `user_preferences` table + `GET/PATCH /preferences` routes following the existing `packageResponse` pattern as a follow-up.
- Install banner sits above the nav row, not docked to the top, to avoid conflicting with `SearchBar` / `ToastContainer` on the home page.
- iOS Safari never fires `beforeinstallprompt`, so the banner simply won't show there — iOS users still use Share → Add to Home Screen. Adding an iOS-specific "how to install" hint is straightforward but also deferred to keep this PR focused.

## Follow-ups

- No migrations, no env vars, no new dependencies.
- If you want a way to re-show the prompt for testing, run `localStorage.removeItem('clapp:install-prompt-dismissed')` in devtools.

## Test plan

- [ ] `cd frontend && npm run build` — pre-existing TS errors in `home.tsx`, `FilterClimbs.tsx`, `ClimbElement.tsx`, `SearchBar.tsx`, `newclimb.tsx` and `main.tsx`'s `ProtectedRoute` typing are present on `main` and untouched by this PR. The new `InstallPrompt.tsx` compiles cleanly.
- [ ] `cd frontend && npm run lint` — no new warnings or errors from files this PR touches.
- [ ] Load the app in Chrome on desktop, confirm the banner appears, click Install, accept — banner should disappear and not return on reload.
- [ ] Reload with `localStorage.getItem('clapp:install-prompt-dismissed') === '1'` — banner stays hidden.
- [ ] Launch the installed PWA (standalone mode) — banner never shows.