### PR TITLE
feat: add silly /eightball Magic 8-Ball page

### DIFF
--- a/frontend/src/pages/eightball.tsx
+++ b/frontend/src/pages/eightball.tsx
@@ -1,0 +1,160 @@
+import {useCallback, useEffect, useRef, useState} from "react";
+import HomeRow from "../components/HomeRow.tsx";
+import "./styles/eightball.css";
+
+const ANSWERS: string[] = [
+    "Send it, champ.",
+    "That project? All yours this session.",
+    "Absolutely — crimp with confidence.",
+    "Flash incoming.",
+    "Your beta is flawless.",
+    "Trust the feet.",
+    "Chalk up and commit.",
+    "Stars are aligned for a send.",
+    "Hmm, take a longer rest first.",
+    "Ask your belayer.",
+    "The holds are spinning... try again.",
+    "Signs point to a heel hook.",
+    "Maybe next burn.",
+    "Not today, flapper city.",
+    "Better chalk up and retry.",
+    "Skin says no. Listen to skin.",
+    "Only if you warm up properly.",
+    "Doubtful — the crux looks spicy.",
+    "Route setter says lol no.",
+    "Core engaged? Then yes."
+];
+
+const ENCOURAGEMENTS: string[] = [
+    "You got this!",
+    "Crush it.",
+    "Strong like gastone.",
+    "Climb on!"
+];
+
+function pickAnswer(): string {
+    return ANSWERS[Math.floor(Math.random() * ANSWERS.length)];
+}
+
+function pickEncouragement(): string {
+    return ENCOURAGEMENTS[Math.floor(Math.random() * ENCOURAGEMENTS.length)];
+}
+
+export default function EightBall() {
+    const [question, setQuestion] = useState<string>("");
+    const [answer, setAnswer] = useState<string>("Ask a climbing question...");
+    const [shaking, setShaking] = useState<boolean>(false);
+    const [revealing, setRevealing] = useState<boolean>(false);
+    const [shakeCount, setShakeCount] = useState<number>(0);
+    const lastShakeRef = useRef<number>(0);
+    const lastMotionRef = useRef<{x: number; y: number; z: number} | null>(null);
+
+    const roll = useCallback(() => {
+        if (shaking) return;
+        setShaking(true);
+        setRevealing(false);
+        const nextAnswer = pickAnswer();
+        setTimeout(() => {
+            setAnswer(nextAnswer);
+            setShaking(false);
+            setRevealing(true);
+        }, 900);
+    }, [shaking]);
+
+    useEffect(() => {
+        const handleMotion = (event: DeviceMotionEvent) => {
+            const acc = event.accelerationIncludingGravity;
+            if (!acc || acc.x == null || acc.y == null || acc.z == null) return;
+            const current = {x: acc.x, y: acc.y, z: acc.z};
+            const prev = lastMotionRef.current;
+            lastMotionRef.current = current;
+            if (!prev) return;
+            const delta =
+                Math.abs(current.x - prev.x) +
+                Math.abs(current.y - prev.y) +
+                Math.abs(current.z - prev.z);
+            const now = Date.now();
+            if (delta > 25 && now - lastShakeRef.current > 1200) {
+                lastShakeRef.current = now;
+                setShakeCount((c) => c + 1);
+                roll();
+            }
+        };
+        window.addEventListener("devicemotion", handleMotion);
+        return () => window.removeEventListener("devicemotion", handleMotion);
+    }, [roll]);
+
+    const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        roll();
+    };
+
+    const requestMotionPermission = async () => {
+        type MotionPermissionCtor = {
+            requestPermission?: () => Promise<"granted" | "denied">;
+        };
+        const ctor = (window as unknown as {DeviceMotionEvent?: MotionPermissionCtor}).DeviceMotionEvent;
+        if (ctor && typeof ctor.requestPermission === "function") {
+            try {
+                await ctor.requestPermission();
+            } catch {
+                // user declined or unavailable
+            }
+        }
+    };
+
+    return (
+        <>
+            <div className="eightball-page">
+                <h1 className="eightball-title">Climbing Magic 8-Ball</h1>
+                <p className="eightball-subtitle">
+                    {pickEncouragement()} Ask the ball about your next send.
+                </p>
+
+                <div
+                    className={`eightball ${shaking ? "shaking" : ""}`}
+                    onClick={roll}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") roll();
+                    }}
+                    aria-label="Shake the magic 8-ball"
+                >
+                    <div className="eightball-inner">
+                        <div className="eightball-window">
+                            <div className={`eightball-triangle ${revealing ? "revealed" : ""} ${shaking ? "hidden" : ""}`}>
+                                <span className="eightball-answer">{answer}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <form className="eightball-form" onSubmit={onSubmit}>
+                    <input
+                        type="text"
+                        className="eightball-input"
+                        placeholder="Will I send my project today?"
+                        value={question}
+                        onChange={(e) => setQuestion(e.target.value)}
+                    />
+                    <button type="submit" className="eightball-button" disabled={shaking}>
+                        {shaking ? "Shaking..." : "Ask the Ball"}
+                    </button>
+                </form>
+
+                <button
+                    type="button"
+                    className="eightball-motion"
+                    onClick={requestMotionPermission}
+                >
+                    Enable shake-to-roll (mobile)
+                </button>
+                {shakeCount > 0 && (
+                    <p className="eightball-shakes">Shakes detected: {shakeCount}</p>
+                )}
+            </div>
+            <HomeRow/>
+        </>
+    );
+}

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import EightBall from "./eightball.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -56,6 +57,7 @@ function Root() {
                     </ProtectedRoute>
                 }
             />
+            <Route path="/eightball" element={<EightBall/>}/>
         </Routes>
     </BrowserRouter>);
 

--- a/frontend/src/pages/styles/eightball.css
+++ b/frontend/src/pages/styles/eightball.css
@@ -1,0 +1,218 @@
+.eightball-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    min-height: 100vh;
+    padding: 48px 16px 120px;
+    gap: 16px;
+    background: radial-gradient(ellipse at top, #1a2a4a 0%, #0a0f1f 70%);
+    color: #f4f4f4;
+}
+
+.eightball-title {
+    font-size: 2.4em;
+    font-weight: 700;
+    text-align: center;
+    margin: 0;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.eightball-subtitle {
+    font-size: 1.1em;
+    text-align: center;
+    opacity: 0.85;
+    margin: 0 0 8px;
+}
+
+.eightball {
+    width: min(80vw, 340px);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 28%, #3a3a3a 0%, #111 55%, #000 100%);
+    box-shadow:
+        inset -30px -30px 80px rgba(0, 0, 0, 0.65),
+        inset 20px 20px 60px rgba(255, 255, 255, 0.06),
+        0 40px 60px rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+    transition: transform 0.2s ease;
+}
+
+.eightball::before {
+    content: "";
+    position: absolute;
+    top: 8%;
+    left: 18%;
+    width: 28%;
+    height: 18%;
+    background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0) 70%);
+    border-radius: 50%;
+    pointer-events: none;
+}
+
+.eightball:hover {
+    transform: scale(1.02);
+}
+
+.eightball:active {
+    transform: scale(0.98);
+}
+
+.eightball-inner {
+    width: 42%;
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    background: #f5f5f5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.2);
+}
+
+.eightball-window {
+    width: 78%;
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    background: radial-gradient(circle, #0f2c5e 0%, #061436 80%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    position: relative;
+}
+
+.eightball-triangle {
+    width: 82%;
+    aspect-ratio: 1 / 1;
+    background: linear-gradient(135deg, #3a6edb 0%, #1c3d7a 100%);
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12% 6% 6%;
+    transition: opacity 0.4s ease, transform 0.5s ease;
+    opacity: 1;
+    transform: translateY(0) rotate(0deg);
+}
+
+.eightball-triangle.hidden {
+    opacity: 0;
+    transform: translateY(30%) rotate(-12deg);
+}
+
+.eightball-triangle.revealed {
+    animation: float-in 0.6s ease-out;
+}
+
+@keyframes float-in {
+    0% {
+        opacity: 0;
+        transform: translateY(30%) rotate(8deg);
+    }
+    60% {
+        opacity: 1;
+        transform: translateY(-6%) rotate(-2deg);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0) rotate(0deg);
+    }
+}
+
+.eightball-answer {
+    color: #ffffff;
+    font-size: 0.75em;
+    font-weight: 600;
+    text-align: center;
+    line-height: 1.2;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding-top: 20%;
+}
+
+.eightball.shaking {
+    animation: shake 0.15s cubic-bezier(0.36, 0.07, 0.19, 0.97) 6 alternate;
+}
+
+@keyframes shake {
+    0% { transform: translate(0, 0) rotate(0deg); }
+    25% { transform: translate(-8px, 4px) rotate(-4deg); }
+    50% { transform: translate(6px, -6px) rotate(3deg); }
+    75% { transform: translate(-4px, 6px) rotate(-2deg); }
+    100% { transform: translate(4px, -4px) rotate(2deg); }
+}
+
+.eightball-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: min(90vw, 420px);
+    margin-top: 8px;
+}
+
+.eightball-input {
+    padding: 12px 16px;
+    border-radius: 24px;
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.08);
+    color: #f4f4f4;
+    font-size: 1em;
+    outline: none;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.eightball-input::placeholder {
+    color: rgba(244, 244, 244, 0.55);
+}
+
+.eightball-input:focus {
+    border-color: #EDCDB7;
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.eightball-button {
+    padding: 14px 24px;
+    border-radius: 32px;
+    font-weight: 600;
+    font-size: 1.1em;
+    background-color: #EDCDB7;
+    color: #1a1a1a;
+    border: 2px solid black;
+    cursor: pointer;
+    transition: transform 0.15s ease, opacity 0.2s ease;
+}
+
+.eightball-button:hover:not(:disabled) {
+    transform: translateY(-2px);
+}
+
+.eightball-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.eightball-motion {
+    margin-top: 4px;
+    padding: 8px 16px;
+    border-radius: 20px;
+    background: transparent;
+    color: #B7D7ED;
+    border: 1px solid rgba(183, 215, 237, 0.5);
+    font-size: 0.85em;
+    cursor: pointer;
+}
+
+.eightball-motion:hover {
+    background: rgba(183, 215, 237, 0.1);
+}
+
+.eightball-shakes {
+    font-size: 0.85em;
+    opacity: 0.7;
+    margin: 0;
+}


### PR DESCRIPTION
## Summary

Adds a silly climbing-themed Magic 8-Ball page at `/eightball`. Users type a question, click or tap the ball (or shake their phone), and get a random encouraging — or discouraging — climbing answer with a smooth shake animation and a float-in reveal for the answer.

## What changed

- New page `frontend/src/pages/eightball.tsx` with:
  - A stylized CSS 8-ball (radial gradients, inner triangle window) in `frontend/src/pages/styles/eightball.css`
  - A question `<input>` and submit button that triggers a roll
  - Click / keyboard / shake-to-roll interaction using `devicemotion`
  - iOS 13+ motion permission prompt behind an "Enable shake-to-roll" button
  - 20 climbing-flavored answers ("Send it, champ", "Skin says no", "Signs point to a heel hook", ...)
- New route `/eightball` registered in `frontend/src/pages/main.tsx` (public, not behind `ProtectedRoute`, since this is just for fun)
- Reuses the existing `HomeRow` bottom nav so users can get back to Home/Add/Profile

## Why

Purely morale — a lightweight fun page that fits the climbing theme without touching the database, auth, or any existing flows.

## Scope & assumptions

- Frontend-only. No backend routes, no Supabase migrations, no new env vars.
- Kept the diff intentionally small: I did **not** add a link to the 8-ball from `HomeRow`, to avoid reflowing the existing 3-button layout and its `1500px` sidebar media query. The page is reachable via the URL `/eightball`; adding a nav entry is a trivial follow-up if desired.
- Styling follows the existing pattern (per-page CSS under `src/pages/styles/`, Inter font, rounded "pill" buttons matching the `log-button`/`#EDCDB7` accent color).

## Build & lint status

- `frontend/` TypeScript build: **pre-existing errors only** — error count is identical (23) with and without this change. The new `eightball.tsx` compiles clean; none of the existing errors trace back to files I touched.
- `frontend/` ESLint: the only remaining error is a pre-existing `react-refresh/only-export-components` warning on `main.tsx` (unchanged line, just shifted by one). `eightball.tsx` lints clean.
- `backend/` TypeScript build: pre-existing errors only — backend was not modified in this PR.

## Follow-ups

- Add a nav entry (button in `HomeRow` or link on the Home page) once the team decides where it should live.
- Optionally persist user questions/answers (would need a `magic_eightball_history` table) — skipped intentionally; this is meant to be ephemeral silliness.