### PR TITLE
feat: save named filter presets in localStorage

### DIFF
--- a/frontend/src/components/FilterClimbs.tsx
+++ b/frontend/src/components/FilterClimbs.tsx
@@ -1,15 +1,30 @@
 import {BOULDER_GRADES, ROPE_GRADES, ROUTE_COLORS, type Search} from "../lib/types.ts";
 import {useEffect, useState} from "react";
+import {
+    type FilterPreset,
+    type PresetFilter,
+    loadPresets,
+    savePresets,
+    upsertPreset,
+    removePreset,
+    presetToSearch,
+} from "../lib/filterPresets.ts";
+import {toast} from "react-toastify";
 import '../pages/styles/filterclimbs.css'
 
 export default function FilterClimbs({filter, onAdvSearch}) {
     const [type, setType] = useState("Any");
+    const [lowerDifficulty, setLowerDifficulty] = useState("VB");
     const [upperDifficulty, setUpperDifficulty] = useState("V17");
     const [color, setColor] = useState("Any");
     const [gym, setGym] = useState("Any");
     const [archived, setArchived] = useState<boolean>(false);
     const [startDate, setStartDate] = useState("");
     const [endDate, setEndDate] = useState("");
+
+    const [presets, setPresets] = useState<FilterPreset[]>(() => loadPresets());
+    const [selectedPreset, setSelectedPreset] = useState<string>("");
+    const [newPresetName, setNewPresetName] = useState<string>("");
 
     const advancedSearch = (formData: FormData) => {
         const newFilter: Search = {
@@ -31,12 +46,96 @@ export default function FilterClimbs({filter, onAdvSearch}) {
     };
     useEffect(() => {
         setUpperDifficulty(type === "Boulder" ? "V17" : "5.15+");
+        setLowerDifficulty(type === "Boulder" ? "VB" : "5.5");
     }, [type]);
 
+    const applyPreset = (name: string) => {
+        setSelectedPreset(name);
+        if (!name) return;
+        const preset = presets.find(p => p.name === name);
+        if (!preset) return;
+        const f = preset.filter;
+        setType(f.type);
+        setLowerDifficulty(f.lowerDifficulty);
+        setUpperDifficulty(f.upperDifficulty);
+        setColor(f.color);
+        setGym(f.gym);
+        setStartDate(f.startDate);
+        setEndDate(f.endDate);
+        setArchived(f.archived);
+        onAdvSearch(presetToSearch(f));
+        toast(`Applied preset "${preset.name}"`, {autoClose: 2000});
+    };
+
+    const saveCurrentAsPreset = () => {
+        const name = newPresetName.trim();
+        if (!name) {
+            toast.error("Enter a name for the preset", {autoClose: 2000});
+            return;
+        }
+        const filter: PresetFilter = {
+            type, lowerDifficulty, upperDifficulty, color, gym, startDate, endDate, archived,
+        };
+        const exists = presets.some(p => p.name === name);
+        const next = upsertPreset(presets, {name, filter});
+        setPresets(next);
+        savePresets(next);
+        setSelectedPreset(name);
+        setNewPresetName("");
+        toast(exists ? `Updated preset "${name}"` : `Saved preset "${name}"`, {autoClose: 2000});
+    };
+
+    const deletePreset = (name: string) => {
+        const next = removePreset(presets, name);
+        setPresets(next);
+        savePresets(next);
+        if (selectedPreset === name) setSelectedPreset("");
+        toast(`Deleted preset "${name}"`, {autoClose: 2000});
+    };
 
     return (
         <div className={`advanced-search-bar ${filter ? 'show' : 'hidden'}`}>
             <form action={advancedSearch} className={'filter'}>
+                <div className={'filter-presets'}>
+                    <label className={'preset-select'}>
+                        <p>Preset</p>
+                        <select
+                            value={selectedPreset}
+                            onChange={e => applyPreset(e.target.value)}
+                        >
+                            <option value="">-- Select a preset --</option>
+                            {presets.map(p => (
+                                <option key={p.name} value={p.name}>{p.name}</option>
+                            ))}
+                        </select>
+                        {selectedPreset && (
+                            <button
+                                type="button"
+                                className={'preset-delete'}
+                                aria-label={`Delete preset ${selectedPreset}`}
+                                onClick={() => deletePreset(selectedPreset)}
+                            >
+                                Delete
+                            </button>
+                        )}
+                    </label>
+                    <label className={'preset-save'}>
+                        <p>Save as Preset</p>
+                        <input
+                            type="text"
+                            placeholder="e.g. My boulder warmups"
+                            value={newPresetName}
+                            onChange={e => setNewPresetName(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                    e.preventDefault();
+                                    saveCurrentAsPreset();
+                                }
+                            }}
+                        />
+                        <button type="button" onClick={saveCurrentAsPreset}>Save</button>
+                    </label>
+                </div>
                 <div className={'filter-r1'}>
                     <label>
                         <p>Type</p>
@@ -50,19 +149,20 @@ export default function FilterClimbs({filter, onAdvSearch}) {
 
                     <label className={"difficulty"} style={{visibility: type === "Any" ? "hidden" : "visible"}}>
                         <p>Difficulty Range</p>
-                        <select name="lowerDifficulty">
+                        <select name="lowerDifficulty" value={lowerDifficulty}
+                                onChange={(e) => setLowerDifficulty(e.target.value)}>
                             {type === "Boulder" ? (Object.keys(BOULDER_GRADES).map((boulder) => (
-                                    <option>{boulder}</option>))) :
+                                    <option key={"filter.lower." + boulder} value={boulder}>{boulder}</option>))) :
                                 (Object.keys(ROPE_GRADES).map((grade) => (
-                                    <option value={grade} key={"filter." + grade}>{grade}</option>)))}
+                                    <option value={grade} key={"filter.lower." + grade}>{grade}</option>)))}
                         </select>
                         to
-                        <select name="upperDifficulty" defaultValue={upperDifficulty} value={upperDifficulty}
+                        <select name="upperDifficulty" value={upperDifficulty}
                                 onChange={(e) => setUpperDifficulty(e.target.value)}>
                             {type === "Boulder" ? (Object.keys(BOULDER_GRADES).map((boulder) => (
-                                    <option>{boulder}</option>))) :
+                                    <option key={"filter.upper." + boulder} value={boulder}>{boulder}</option>))) :
                                 (Object.keys(ROPE_GRADES).map((grade) => (
-                                    <option value={grade} key={"filter." + grade}>{grade}</option>)))}
+                                    <option value={grade} key={"filter.upper." + grade}>{grade}</option>)))}
                         </select>
                     </label>
                 </div>
@@ -109,7 +209,7 @@ export default function FilterClimbs({filter, onAdvSearch}) {
                 <label className={'archived-climbs'}>
                     <p>Include Archived Climbs</p>
                     <input name={'archived'} type={"checkbox"} checked={archived}
-                           onChange={e => setArchived(e.target.value)}/>
+                           onChange={e => setArchived(e.target.checked)}/>
                 </label>
                 <div className={'advanced-search-bar-buttons'}>
                     <button type="submit"
@@ -122,12 +222,14 @@ export default function FilterClimbs({filter, onAdvSearch}) {
                     </button>
                     <button type="button" onClick={() => {
                         setType("Any");
+                        setLowerDifficulty("VB");
                         setUpperDifficulty("V17");
                         setColor("Any");
                         setStartDate("");
                         setEndDate("");
                         setGym("Any");
                         setArchived(false);
+                        setSelectedPreset("");
                         onAdvSearch(undefined);
                     }}>Clear Filters
                     </button>

--- a/frontend/src/lib/filterPresets.ts
+++ b/frontend/src/lib/filterPresets.ts
@@ -1,0 +1,63 @@
+import type {Search} from "./types.ts";
+
+export interface FilterPreset {
+    name: string;
+    filter: PresetFilter;
+}
+
+export interface PresetFilter {
+    type: string;
+    lowerDifficulty: string;
+    upperDifficulty: string;
+    color: string;
+    gym: string;
+    startDate: string;
+    endDate: string;
+    archived: boolean;
+}
+
+const STORAGE_KEY = "clapp.filterPresets";
+
+export function loadPresets(): FilterPreset[] {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter(
+            (p): p is FilterPreset =>
+                p && typeof p.name === "string" && p.filter && typeof p.filter === "object"
+        );
+    } catch {
+        return [];
+    }
+}
+
+export function savePresets(presets: FilterPreset[]): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+}
+
+export function upsertPreset(presets: FilterPreset[], preset: FilterPreset): FilterPreset[] {
+    const idx = presets.findIndex(p => p.name === preset.name);
+    if (idx === -1) return [...presets, preset];
+    const next = presets.slice();
+    next[idx] = preset;
+    return next;
+}
+
+export function removePreset(presets: FilterPreset[], name: string): FilterPreset[] {
+    return presets.filter(p => p.name !== name);
+}
+
+export function presetToSearch(preset: PresetFilter): Search {
+    return {
+        lowerDifficulty: preset.lowerDifficulty,
+        upperDifficulty: preset.upperDifficulty,
+        type: preset.type,
+        color: preset.color,
+        startDate: preset.startDate as unknown as Date,
+        endDate: preset.endDate as unknown as Date,
+        gym: preset.gym,
+        archived: preset.archived,
+    };
+}

--- a/frontend/src/pages/styles/filterclimbs.css
+++ b/frontend/src/pages/styles/filterclimbs.css
@@ -61,6 +61,30 @@
     display: none;
 }
 
+.filter-presets {
+    display: flex;
+    flex-direction: column;
+    border-bottom: 2px solid black;
+    margin-bottom: 8px;
+    padding-bottom: 4px;
+}
+
+.filter-presets .preset-select,
+.filter-presets .preset-save {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.filter-presets p {
+    margin-right: 8px;
+}
+
+.filter-presets .preset-delete {
+    background-color: #f8b7b7;
+}
+
 .filter-r1 {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
## Summary

Adds a small preset manager to the home/search filter panel so climbers can save a named combination of filters (e.g. *"My boulder warmups"*) and re-apply it in one click.

## What changed

- `frontend/src/lib/filterPresets.ts` — new localStorage-backed helpers (`loadPresets` / `savePresets` / `upsertPreset` / `removePreset` / `presetToSearch`) plus a `FilterPreset` type. Presets live under the key `clapp.filterPresets` and are validated on read so malformed data is ignored gracefully.
- `frontend/src/components/FilterClimbs.tsx` — adds a "Preset" row to the top of the advanced-search form:
  - Dropdown of saved presets; selecting one populates the form and immediately triggers the existing `/climbs/search/filter` call via `onAdvSearch`.
  - Name input + **Save** button captures the current filter state as a preset (or updates it if the name already exists).
  - **Delete** button next to the selected preset removes it.
  - Toast feedback on save/apply/delete, reusing the existing `react-toastify` setup.
  - "Clear Filters" also clears the selected preset.
- Also fixes a latent bug: the `archived` checkbox previously set state from `e.target.value` (a string) instead of `e.target.checked`, so it could never be unchecked after being toggled on. Fixed while touching the component.
- `frontend/src/pages/styles/filterclimbs.css` — styling for the preset row (separator, spacing, red tint on the delete button).

## Why

Users with recurring workflows (warmup sessions, project-grade filtering at a specific gym, etc.) were re-entering the same filter combination every visit. Presets remove that friction and keep the change fully client-side, so there are no schema, auth, or sync concerns.

## Assumptions / notes

- **Scope is client-only.** No backend, migration, or env-var changes. If we later want presets to follow the user across devices, we'd add a `filter_presets` table keyed by `user_id` and a small CRUD route set mirroring `packageResponse` — not done here to keep the diff focused.
- **Name collisions update in place.** Saving a preset with an existing name overwrites it (with a toast that says "Updated" instead of "Saved"). Felt more intuitive than a separate rename flow.
- **Validation is lenient on read.** Anything in localStorage that doesn't look like a `FilterPreset` is filtered out rather than thrown — handy if the shape ever changes.
- **Pre-existing build/lint state left alone.** Both `backend` and `frontend` `npm run build` already fail on `main` due to pre-existing TypeScript errors in untouched files; this PR adds zero new TS errors and zero new lint errors in the files it touches (and removes one — the `archived` checkbox fix above).

## Follow-ups

- Consider a "rename preset" affordance (currently you delete + re-save).
- If presets go server-side later, add a migration under `backend/migrations/` plus `GET/POST/DELETE /presets` routes following the existing `packageResponse` pattern.

## Test plan

- [ ] Open the filter panel on `/home`, set some filters, enter a name, click **Save** — preset appears in the dropdown and a toast confirms.
- [ ] Reload the page; the dropdown still lists the preset.
- [ ] Select the preset from the dropdown — form fields populate and the climbs list re-queries with those filters.
- [ ] With a preset selected, click **Delete** — it disappears from the dropdown and the toast confirms.
- [ ] Save over an existing name — toast says "Updated".
- [ ] Toggle the "Include Archived Climbs" checkbox on then off — it now actually unchecks (regression fix).