### PR TITLE
feat: add Climb of the Day card to home page

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -35,6 +35,13 @@ export function setupRoutes(server: FastifyInstance) {
         return res.status(code).send(result);
     });
 
+    server.get<{
+        Reply: any[] | { error: string };
+    }>("/climbs/of-the-day", async (req, res) => {
+        const {reply: result, code} = await packageResponse(() => handleClimbOfTheDay());
+        return res.status(code).send(result);
+    });
+
     server.post<{
         Body: Climb;
         Reply: BaseReply<void>;
@@ -91,6 +98,21 @@ export function setupRoutes(server: FastifyInstance) {
         }
         return {success: true, data: data};
 
+    }
+
+    async function handleClimbOfTheDay(): Promise<Task> {
+        const {data, error} = await server.supabase.from("climbs")
+            .select("*").eq("archived", false).order("id", {ascending: true});
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        if (!data || data.length === 0) {
+            return {success: true, data: null as any};
+        }
+        const now = new Date();
+        const seed = now.getUTCFullYear() * 10000 + (now.getUTCMonth() + 1) * 100 + now.getUTCDate();
+        const index = seed % data.length;
+        return {success: true, data: data[index]};
     }
 
 //TODO: Handle pictures

--- a/frontend/src/components/ClimbOfTheDay.tsx
+++ b/frontend/src/components/ClimbOfTheDay.tsx
@@ -1,0 +1,102 @@
+import {useEffect, useState} from "react";
+import {BACKEND_URL, ROUTE_COLORS} from "../lib/types.ts";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import {toast} from "react-toastify";
+import "../pages/styles/climboftheday.css";
+
+interface DailyClimb {
+    id: number;
+    name: string;
+    difficulty: string;
+    type: string;
+    color: string;
+    setter: string;
+    gym: string;
+}
+
+export default function ClimbOfTheDay() {
+    const [climb, setClimb] = useState<DailyClimb | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [logging, setLogging] = useState(false);
+
+    useEffect(() => {
+        const fetchClimbOfTheDay = async () => {
+            setLoading(true);
+            try {
+                const response = await fetch(`${BACKEND_URL}/climbs/of-the-day`);
+                const data = await response.json();
+                if (data.success && data.data) {
+                    setClimb(data.data);
+                }
+            } catch (err) {
+                console.log("Failed to fetch climb of the day:", err);
+            }
+            setLoading(false);
+        };
+        fetchClimbOfTheDay();
+    }, []);
+
+    const handleLog = async () => {
+        if (!climb || logging) return;
+        setLogging(true);
+        const {data: {user}} = await supabaseClient.auth.getUser();
+        if (!user) {
+            toast.error("You must be signed in to log a climb", {autoClose: 2500});
+            setLogging(false);
+            return;
+        }
+        const response = await fetch(`${BACKEND_URL}/climbs/log`, {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({user: user.id, climb: climb.id}),
+        });
+        const data = await response.json();
+        if (data.success) {
+            toast("Climb of the Day logged!", {autoClose: 2500});
+        } else {
+            toast.error("Failed to log Climb of the Day", {autoClose: 2500});
+        }
+        setLogging(false);
+    };
+
+    if (loading) {
+        return (
+            <div className={"climb-of-the-day-card climb-of-the-day-empty"}>
+                <p>Finding today's climb...</p>
+            </div>
+        );
+    }
+
+    if (!climb) {
+        return (
+            <div className={"climb-of-the-day-card climb-of-the-day-empty"}>
+                <h2>Climb of the Day</h2>
+                <p>No climbs are available yet. Add one to get started!</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className={"climb-of-the-day-card"}>
+            <div className={"climb-of-the-day-header"}>
+                <span className={"climb-of-the-day-badge"}>Climb of the Day</span>
+                <div
+                    className={"climb-of-the-day-color"}
+                    style={{backgroundColor: ROUTE_COLORS[climb.color]}}
+                />
+            </div>
+            <h2 className={"climb-of-the-day-name"}>{climb.name}</h2>
+            <p className={"climb-of-the-day-meta"}>
+                {climb.difficulty} • {climb.type} • {climb.gym}
+            </p>
+            <p className={"climb-of-the-day-setter"}>Set by {climb.setter}</p>
+            <button
+                className={"climb-of-the-day-button"}
+                onClick={handleLog}
+                disabled={logging}
+            >
+                {logging ? "Logging..." : "Log it"}
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -3,6 +3,7 @@ import "./styles/home.css"
 import HomeRow from "../components/HomeRow.tsx";
 import {startTransition, useEffect, useOptimistic, useState} from "react";
 import ClimbElement from "../components/ClimbElement.tsx";
+import ClimbOfTheDay from "../components/ClimbOfTheDay.tsx";
 import {supabaseClient} from "../util/supabaseClient.ts";
 import type {User} from "@supabase/supabase-js";
 import {BACKEND_URL, type Search} from "../lib/types.ts";
@@ -149,6 +150,8 @@ export default function Home() {
         <SearchBar onSearch={onSearch} onFilter={onFilter} filtering={filtering}/>
         <FilterClimbs filter={filter} onAdvSearch={onAdvSearch}/>
         <ToastContainer className={'toast'}/>
+
+        <ClimbOfTheDay/>
 
         <div className={"climbs"}>
 

--- a/frontend/src/pages/styles/climboftheday.css
+++ b/frontend/src/pages/styles/climboftheday.css
@@ -1,0 +1,77 @@
+.climb-of-the-day-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    background-color: #EDCDB7;
+    border: 2px solid black;
+    border-radius: 16px;
+    padding: 16px 20px;
+    margin: 16px;
+    width: calc(100% - 32px);
+    max-width: 560px;
+    box-sizing: border-box;
+    box-shadow: 0 4px 0 rgba(0, 0, 0, 0.1);
+}
+
+.climb-of-the-day-empty {
+    align-items: center;
+    text-align: center;
+}
+
+.climb-of-the-day-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.climb-of-the-day-badge {
+    font-weight: 700;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    background-color: #B7D7ED;
+    border: 2px solid black;
+    border-radius: 999px;
+    padding: 4px 10px;
+}
+
+.climb-of-the-day-color {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid black;
+}
+
+.climb-of-the-day-name {
+    margin: 12px 0 4px 0;
+    font-size: 24px;
+}
+
+.climb-of-the-day-meta {
+    margin: 2px 0;
+    font-size: 15px;
+}
+
+.climb-of-the-day-setter {
+    margin: 2px 0 12px 0;
+    font-size: 14px;
+    opacity: 0.75;
+}
+
+.climb-of-the-day-button {
+    align-self: stretch;
+    padding: 12px 20px;
+    border-radius: 999px;
+    background-color: #B7D7ED;
+    border: 2px solid black;
+    font-weight: 600;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.climb-of-the-day-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary

Adds a **Climb of the Day** feature to the home page: a card that deterministically surfaces one featured climb per day (same for every user) and lets them log the ascent with a single click.

## What changed

**Backend** (`backend/src/routes.ts`)
- New `GET /climbs/of-the-day` endpoint following the existing `packageResponse` pattern.
- Selects all non-archived climbs ordered by `id`, then picks `climbs[seed % N]` where `seed = yyyy*10000 + mm*100 + dd` in UTC. This gives a deterministic per-day pick that is stable across users and servers, and rolls over at UTC midnight.
- Returns `null` gracefully when the table is empty.

**Frontend**
- New `ClimbOfTheDay` component (`frontend/src/components/ClimbOfTheDay.tsx`) rendered at the top of `home.tsx`. Fetches the daily climb, shows name / grade / type / gym / setter / hold color, and offers a "Log it" button that posts to the existing `POST /climbs/log` endpoint with the current Supabase user's id.
- Styling in `frontend/src/pages/styles/climboftheday.css` keeps the palette consistent with the existing home UI (same cream/blue pair used by `.log-button`).

## Assumptions & notes

- **No migration required.** Re-uses the existing `climbs` and `completed_climbs` tables — the feature is purely a read-side selection plus the existing log mutation, so nothing is added to `migrations/`.
- **Selection determinism.** `(UTC date) % N` over an id-sorted list is stable as long as climbs aren't deleted mid-day; since the app archives rather than deletes (`handleArchive` flips `archived=true`), the filtered list is stable enough for a daily pick. Archiving a currently-featured climb before midnight will shift the pick — acceptable trade-off for this feature.
- **Duplicate logs.** The existing `/climbs/log` handler has a `// TODO: prevent climbs from being logged twice` note; this PR does not address that, so a user can currently tap "Log it" multiple times and create duplicate `completed_climbs` rows. Follow-up.
- **Pre-existing TS/lint errors.** Both `backend` and `frontend` builds already fail on `main` with a number of TypeScript errors (e.g. `Task` return type vs. `any[]` data in every handler, implicit-`any` props in `SearchBar`/`FilterClimbs`, etc.). This PR does not introduce any new errors — the new component and endpoint are typed cleanly — but it also does not attempt to fix the existing ones, to keep the diff focused.

## Follow-ups

- Prevent duplicate logging from the Climb of the Day button (and the main list).
- Consider a DB view or RPC for the daily pick if the climbs table grows large, so we don't pull the whole non-archived set per request.
- Optional: persist "today's climb" so an archive mid-day doesn't change the pick.

## Test plan

- [ ] `GET /climbs/of-the-day` returns the same climb for repeated calls within a UTC day, and a different climb the next day (when N > 1).
- [ ] Home page shows the Climb of the Day card above the main grid, with the hold color, grade, gym, and setter.
- [ ] "Log it" button creates a row in `completed_climbs` for the current user and shows the success toast; failure path shows the error toast.
- [ ] Empty-database case shows the "No climbs are available yet" empty state instead of crashing.