### PR TITLE
feat: add Clappy AI chatbot widget with backend OpenAI proxy

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -11,8 +11,24 @@ import {
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
+    BOULDER_GRADES, type Log,
+    type ChatRequest,
+    type ChatResponse,
+    type ChatMessage
 } from "../../frontend/src/lib/types.ts";
+
+const CHATBOT_SYSTEM_PROMPT = `You are Clappy, a friendly climbing assistant inside the Clapp app — a route-logging tool for indoor climbers.
+
+Your job is two-fold:
+1. Answer climbing questions: grades (YDS, V-scale), technique, training, gear, etiquette, safety.
+2. Help users navigate Clapp. Key routes:
+   - /home — browse featured climbs, search, filter, and log a completed climb.
+   - /logclimb — add a brand new route to the gym catalog (name, type, difficulty, color, setter, gym).
+   - /profile — see climbs the user has completed.
+
+Climb types are "Boulder" (V-scale) and "Top Rope" (YDS 5.x). Supported gyms: Fetzer, Ram's Head.
+
+Keep answers concise (2–4 sentences). If a user asks how to do something in the app, tell them which page to go to and what to click. If a question is off-topic or unsafe, politely redirect.`;
 
 //TODO: add post request for claiming a set climb, and ticking a climb
 export function setupRoutes(server: FastifyInstance) {
@@ -67,6 +83,14 @@ export function setupRoutes(server: FastifyInstance) {
         Reply: BaseReply<void>;
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.post<{
+        Body: ChatRequest;
+        Reply: BaseReply<ChatResponse> | { error: string };
+    }>("/chat", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleChat(req.body));
         res.status(code).send(reply);
     });
 
@@ -209,6 +233,82 @@ export function setupRoutes(server: FastifyInstance) {
             } else if (bound === "upper") {
                 return gradeList.filter(grade => BOULDER_GRADES[grade] <= BOULDER_GRADES[filterGrade]);
             }
+        }
+    }
+
+    async function handleChat(req: ChatRequest): Promise<Process<ChatResponse>> {
+        const apiKey = process.env.OPENAI_API_KEY;
+        const baseUrl = process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1";
+        const model = process.env.OPENAI_MODEL ?? "gpt-4o-mini";
+
+        if (!apiKey) {
+            return {
+                success: false,
+                error: new Error("Chatbot is not configured: OPENAI_API_KEY env var is missing."),
+                code: 503
+            };
+        }
+
+        if (!req || !Array.isArray(req.messages) || req.messages.length === 0) {
+            return {
+                success: false,
+                error: new Error("messages[] is required"),
+                code: 400
+            };
+        }
+
+        const userFacing: ChatMessage[] = req.messages
+            .filter(m => m && (m.role === "user" || m.role === "assistant") && typeof m.content === "string")
+            .slice(-20)
+            .map(m => ({role: m.role, content: m.content.slice(0, 4000)}));
+
+        const payload = {
+            model,
+            messages: [
+                {role: "system", content: CHATBOT_SYSTEM_PROMPT},
+                ...userFacing
+            ],
+            temperature: 0.4,
+            max_tokens: 400
+        };
+
+        try {
+            const upstream = await fetch(`${baseUrl}/chat/completions`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${apiKey}`
+                },
+                body: JSON.stringify(payload)
+            });
+
+            if (!upstream.ok) {
+                const text = await upstream.text();
+                server.log.error({status: upstream.status, body: text}, "chat upstream error");
+                return {
+                    success: false,
+                    error: new Error(`Upstream chat API returned ${upstream.status}`),
+                    code: 502
+                };
+            }
+
+            const data: any = await upstream.json();
+            const reply: string | undefined = data?.choices?.[0]?.message?.content;
+            if (!reply) {
+                return {
+                    success: false,
+                    error: new Error("Upstream chat API returned no content"),
+                    code: 502
+                };
+            }
+            return {success: true, data: {reply}};
+        } catch (err) {
+            server.log.error(err, "chat handler failed");
+            return {
+                success: false,
+                error: err instanceof Error ? err : new Error(String(err)),
+                code: 502
+            };
         }
     }
 

--- a/frontend/src/components/ChatBot.tsx
+++ b/frontend/src/components/ChatBot.tsx
@@ -1,0 +1,135 @@
+import {useEffect, useRef, useState} from "react";
+import {BACKEND_URL, type ChatMessage} from "../lib/types.ts";
+import "../pages/styles/chatbot.css";
+
+const INTRO: ChatMessage = {
+    role: "assistant",
+    content: "Hi! I'm Clappy. Ask me about climbing or how to use Clapp."
+};
+
+export default function ChatBot() {
+    const [open, setOpen] = useState(false);
+    const [messages, setMessages] = useState<ChatMessage[]>([INTRO]);
+    const [input, setInput] = useState("");
+    const [sending, setSending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (scrollRef.current) {
+            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        }
+    }, [messages, open]);
+
+    useEffect(() => {
+        if (open && inputRef.current) {
+            inputRef.current.focus();
+        }
+    }, [open]);
+
+    const send = async () => {
+        const trimmed = input.trim();
+        if (!trimmed || sending) return;
+
+        const nextMessages: ChatMessage[] = [...messages, {role: "user", content: trimmed}];
+        setMessages(nextMessages);
+        setInput("");
+        setSending(true);
+        setError(null);
+
+        try {
+            const response = await fetch(`${BACKEND_URL}/chat`, {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({messages: nextMessages}),
+            });
+            const data = await response.json();
+            if (data.success) {
+                setMessages([...nextMessages, {role: "assistant", content: data.data.reply}]);
+            } else {
+                const msg = data.message || data.error || "Chatbot is unavailable.";
+                setError(msg);
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Network error");
+        } finally {
+            setSending(false);
+        }
+    };
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            send();
+        }
+    };
+
+    return (
+        <div className={`chatbot ${open ? "open" : ""}`}>
+            {open && (
+                <div className={"chatbot-panel"}>
+                    <div className={"chatbot-header"}>
+                        <span>Clappy</span>
+                        <button
+                            type="button"
+                            aria-label="Close chat"
+                            className={"chatbot-close"}
+                            onClick={() => setOpen(false)}
+                        >
+                            ×
+                        </button>
+                    </div>
+                    <div className={"chatbot-messages"} ref={scrollRef}>
+                        {messages.map((m, i) => (
+                            <div key={i} className={`chatbot-message ${m.role}`}>
+                                {m.content}
+                            </div>
+                        ))}
+                        {sending && (
+                            <div className={"chatbot-message assistant chatbot-typing"}>…</div>
+                        )}
+                        {error && (
+                            <div className={"chatbot-error"}>{error}</div>
+                        )}
+                    </div>
+                    <div className={"chatbot-input-row"}>
+                        <input
+                            ref={inputRef}
+                            type="text"
+                            value={input}
+                            onChange={(e) => setInput(e.target.value)}
+                            onKeyDown={onKeyDown}
+                            placeholder="Ask a climbing question…"
+                            disabled={sending}
+                        />
+                        <button
+                            type="button"
+                            className={"chatbot-send"}
+                            onClick={send}
+                            disabled={sending || !input.trim()}
+                        >
+                            Send
+                        </button>
+                    </div>
+                </div>
+            )}
+            <button
+                type="button"
+                aria-label={open ? "Close chat" : "Open chat"}
+                className={"chatbot-toggle"}
+                onClick={() => setOpen(v => !v)}
+            >
+                {open ? (
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 16 16">
+                        <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"/>
+                    </svg>
+                ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 16 16">
+                        <path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0m4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0m3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/>
+                    </svg>
+                )}
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,19 @@ export interface Log {
     climb: number;
 }
 
+export interface ChatMessage {
+    role: "system" | "user" | "assistant";
+    content: string;
+}
+
+export interface ChatRequest {
+    messages: ChatMessage[];
+}
+
+export interface ChatResponse {
+    reply: string;
+}
+
 export const BACKEND_URL: string = 'http://localhost:8000';
 export const FRONTEND_URL: string = 'http://localhost:5173';
 

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import ChatBot from "../components/ChatBot.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -57,6 +58,7 @@ function Root() {
                 }
             />
         </Routes>
+        {session && <ChatBot/>}
     </BrowserRouter>);
 
 }

--- a/frontend/src/pages/styles/chatbot.css
+++ b/frontend/src/pages/styles/chatbot.css
@@ -1,0 +1,153 @@
+.chatbot {
+    position: fixed;
+    bottom: 80px;
+    right: 16px;
+    z-index: 5;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 12px;
+    pointer-events: none;
+}
+
+.chatbot > * {
+    pointer-events: auto;
+}
+
+.chatbot-toggle {
+    width: 56px;
+    height: 56px;
+    border-radius: 28px;
+    background-color: #EDCDB7;
+    border: 2px solid black;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    padding: 0;
+}
+
+.chatbot-toggle:hover {
+    background-color: #e3bfa5;
+}
+
+.chatbot-panel {
+    width: 320px;
+    max-width: calc(100vw - 32px);
+    height: 440px;
+    max-height: calc(100vh - 180px);
+    background-color: #fff;
+    border: 2px solid black;
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.chatbot-header {
+    background-color: #EDCDB7;
+    border-bottom: 2px solid black;
+    padding: 8px 12px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.chatbot-close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+    color: black;
+}
+
+.chatbot-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background-color: #fafafa;
+}
+
+.chatbot-message {
+    padding: 8px 12px;
+    border-radius: 12px;
+    max-width: 85%;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    line-height: 1.35;
+    font-size: 14px;
+}
+
+.chatbot-message.user {
+    align-self: flex-end;
+    background-color: #B7D7ED;
+    border: 1px solid #6fa3c8;
+}
+
+.chatbot-message.assistant {
+    align-self: flex-start;
+    background-color: #EDCDB7;
+    border: 1px solid #b88a62;
+}
+
+.chatbot-typing {
+    font-style: italic;
+    opacity: 0.7;
+}
+
+.chatbot-error {
+    color: #a00;
+    font-size: 13px;
+    align-self: center;
+    text-align: center;
+}
+
+.chatbot-input-row {
+    display: flex;
+    border-top: 2px solid black;
+    padding: 8px;
+    gap: 8px;
+    background-color: #fff;
+}
+
+.chatbot-input-row input {
+    flex: 1;
+    border: 1px solid #999;
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-size: 14px;
+    outline: none;
+}
+
+.chatbot-input-row input:focus {
+    border-color: black;
+}
+
+.chatbot-send {
+    background-color: #EDCDB7;
+    border: 2px solid black;
+    border-radius: 8px;
+    padding: 6px 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.chatbot-send:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+@media only screen and (min-width: 1500px) {
+    .chatbot {
+        bottom: 24px;
+        right: 24px;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a floating chatbot (**Clappy**) pinned to the bottom-right corner of every authenticated page in the app. It answers climbing questions (grades, technique, gear, etiquette) and helps users navigate Clapp by pointing them at the right pages (`/home`, `/logclimb`, `/profile`).

The widget talks to a new `POST /chat` route on the Fastify backend that proxies to any OpenAI-compatible chat-completions API using a server-side API key. The key is never exposed to the browser.

## What changed

- **Backend** (`backend/src/routes.ts`): new `POST /chat` route that accepts `{ messages: ChatMessage[] }`, injects a Clappy system prompt, and forwards to `${OPENAI_BASE_URL}/chat/completions` with `OPENAI_API_KEY`. Returns a `BaseReply<{reply: string}>` matching the existing `packageResponse` pattern. Caps to the last 20 messages and 4 KB per message. Non-2xx upstream → 502.
- **Frontend** (`frontend/src/components/ChatBot.tsx` + `frontend/src/pages/styles/chatbot.css`): floating toggle button with an expandable chat panel, message history, typing indicator, and error state. Mounted once in `main.tsx` inside `<BrowserRouter>` so it overlays every route; it only renders while a Supabase session exists, so it stays off the login page.
- **Types** (`frontend/src/lib/types.ts`): new `ChatMessage`, `ChatRequest`, `ChatResponse` types shared between frontend and backend.

## Required env vars (backend)

Add to `backend/.env.*`:

| Var | Required | Default | Notes |
| --- | --- | --- | --- |
| `OPENAI_API_KEY` | **yes** | — | Any OpenAI-compatible key (OpenAI, Groq, Together, OpenRouter, local). Placeholder — no real key is committed. |
| `OPENAI_BASE_URL` | no | `https://api.openai.com/v1` | Override to point at a compatible provider. |
| `OPENAI_MODEL` | no | `gpt-4o-mini` | Any chat-completions model. |

If `OPENAI_API_KEY` is missing, the route returns **503** with a clear message and the frontend surfaces the error inline — the rest of the app is unaffected.

## Assumptions

- "OpenAI-compatible" API is interpreted as any server that implements the `/chat/completions` shape — this keeps the backend provider-agnostic.
- The widget is only useful to signed-in users, so it's gated on `session` in `main.tsx`. Moving it outside the gate is a one-line change if the login page should have it too.
- No database/auth changes needed, so no migration is included.

## Follow-ups / known issues

- The backend and frontend had **pre-existing TypeScript errors on `main`** (25 in `backend/src/routes.ts`, 23 across various frontend files — counts verified by running `tsc -b` both with and without this branch's changes). This PR introduces **zero new** TS or ESLint errors; only `backend/src/routes.ts` error line numbers shift because the file grew. Cleaning those up is out of scope here.
- Consider streaming responses (SSE) later for a snappier feel — current implementation returns the full completion in one shot.
- Consider rate-limiting `/chat` per IP before exposing publicly.

## Test plan

- [ ] Set `OPENAI_API_KEY` in `backend/.env.development` and start both servers (`npm run dev` in each).
- [ ] Log in, confirm the chat bubble appears bottom-right on `/home`, `/logclimb`, `/profile` and **not** on the login page.
- [ ] Open the panel, ask "What's a V3?" — expect a concise climbing answer.
- [ ] Ask "How do I log a climb?" — expect Clappy to direct you to `/home` / `/logclimb`.
- [ ] Unset `OPENAI_API_KEY` and restart the backend — sending a message should surface an inline error, not crash the app.