### PR TITLE
feat: session logger — group completed climbs into dated sessions

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -11,7 +11,9 @@ import {
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
+    BOULDER_GRADES,
+    type Log,
+    type SessionInput
 } from "../../frontend/src/lib/types.ts";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
@@ -67,6 +69,33 @@ export function setupRoutes(server: FastifyInstance) {
         Reply: BaseReply<void>;
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.get<{
+        Reply: any[] | { error: string };
+    }>("/sessions/:uuid", async (req, res) => {
+        const {reply: result, code} = await packageResponse(() => handleListSessions(req.params));
+        return res.status(code).send(result);
+    });
+
+    server.get<{
+        Reply: any | { error: string };
+    }>("/sessions/detail/:id", async (req, res) => {
+        const {reply: result, code} = await packageResponse(() => handleGetSession(req.params));
+        return res.status(code).send(result);
+    });
+
+    server.post<{
+        Body: SessionInput;
+        Reply: BaseReply<void>;
+    }>("/sessions/new", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleNewSession(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.delete("/sessions/:id", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleDeleteSession(req.params));
         res.status(code).send(reply);
     });
 
@@ -224,6 +253,86 @@ export function setupRoutes(server: FastifyInstance) {
         return {success: true, data: data};
     }
 
+
+    async function handleListSessions(params: { uuid?: string }): Promise<Task> {
+        const {uuid} = params;
+        const {data, error} = await server.supabase
+            .from("sessions")
+            .select("*")
+            .eq("climber", uuid)
+            .order("session_date", {ascending: false});
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleGetSession(params: { id?: string }): Promise<Task> {
+        const {id} = params;
+        const {data, error} = await server.supabase
+            .from("sessions")
+            .select(`
+                *,
+                session_climbs:session_climbs (
+                    id,
+                    completed_climb_id,
+                    completed_climbs:completed_climb_id (
+                        *,
+                        climbs:climb(*)
+                    )
+                )
+            `)
+            .eq("id", id)
+            .maybeSingle();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleNewSession(req: SessionInput): Promise<Task> {
+        const {user, sessionDate, durationMin, notes, completedClimbIds} = req;
+        if (!user || !sessionDate) {
+            return {success: false, error: new Error("user and sessionDate are required"), code: 400};
+        }
+        const {data: sessionRows, error: sessionErr} = await server.supabase
+            .from("sessions")
+            .insert([{
+                climber: user,
+                session_date: sessionDate,
+                duration_min: durationMin,
+                notes: notes,
+            }])
+            .select();
+        if (sessionErr) {
+            return {success: false, error: sessionErr, code: 500};
+        }
+        const sessionId = sessionRows?.[0]?.id;
+        if (sessionId && completedClimbIds && completedClimbIds.length > 0) {
+            const rows = completedClimbIds.map((cid) => ({
+                session_id: sessionId,
+                completed_climb_id: cid,
+            }));
+            const {error: joinErr} = await server.supabase.from("session_climbs").insert(rows);
+            if (joinErr) {
+                return {success: false, error: joinErr, code: 500};
+            }
+        }
+        return {success: true, data: sessionRows};
+    }
+
+    async function handleDeleteSession(params: { id?: string }): Promise<Task> {
+        const {id} = params;
+        const {data, error} = await server.supabase
+            .from("sessions")
+            .delete()
+            .eq("id", id)
+            .select();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
 
     async function packageResponse<O>(handler: () => Promise<Process<O>>,): Promise<ReplyConfig<O>> {
         const result = await handler();

--- a/frontend/src/components/HomeRow.tsx
+++ b/frontend/src/components/HomeRow.tsx
@@ -22,6 +22,15 @@ export default function HomeRow() {
                 </svg>
                 <p>Add Climb</p>
             </div>
+            <div className={'sessions-button'} onClick={() => navigate("/sessions")}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
+                     className="bi bi-journal-text" viewBox="0 0 16 16">
+                    <path d="M5 10.5a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1h-2a.5.5 0 0 1-.5-.5m0-2a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5m0-2a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5m0-2a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5"/>
+                    <path d="M3 0h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-1h1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v1H1V2a2 2 0 0 1 2-2"/>
+                    <path d="M1 5v-.5a.5.5 0 0 1 1 0V5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1zm0 3v-.5a.5.5 0 0 1 1 0V8h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1zm0 3v-.5a.5.5 0 0 1 1 0v.5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1z"/>
+                </svg>
+                <p>Sessions</p>
+            </div>
             <div className={'profile-button'} onClick={() => navigate("/profile")}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
                      className="bi bi-person" viewBox="0 0 16 16" >

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,32 @@ export interface Log {
     climb: number;
 }
 
+export interface SessionInput {
+    user: string;
+    sessionDate: string;
+    durationMin: number | null;
+    notes: string;
+    completedClimbIds: number[];
+}
+
+export interface SessionRecord {
+    id: number;
+    climber: string;
+    session_date: string;
+    duration_min: number | null;
+    notes: string | null;
+    created_at: string;
+    session_climbs?: Array<{
+        id: number;
+        completed_climb_id: number;
+        completed_climbs?: {
+            id: number;
+            climb: number;
+            climbs?: Climb & { id: number };
+        } | null;
+    }>;
+}
+
 export const BACKEND_URL: string = 'http://localhost:8000';
 export const FRONTEND_URL: string = 'http://localhost:5173';
 

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,8 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import Sessions from "./sessions.tsx";
+import NewSession from "./newsession.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -53,6 +55,22 @@ function Root() {
                 element={
                     <ProtectedRoute session={session}>
                         <Profile/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/sessions"
+                element={
+                    <ProtectedRoute session={session}>
+                        <Sessions/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/sessions/new"
+                element={
+                    <ProtectedRoute session={session}>
+                        <NewSession/>
                     </ProtectedRoute>
                 }
             />

--- a/frontend/src/pages/newsession.tsx
+++ b/frontend/src/pages/newsession.tsx
@@ -1,0 +1,133 @@
+import "./styles/sessions.css";
+import HomeRow from "../components/HomeRow.tsx";
+import {useEffect, useState} from "react";
+import {useNavigate} from "react-router-dom";
+import type {User} from "@supabase/supabase-js";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import {BACKEND_URL, type SessionInput} from "../lib/types.ts";
+import {toast, ToastContainer} from "react-toastify";
+
+interface CompletedClimbRow {
+    id: number;
+    climb: number;
+    climbs: {
+        id: number;
+        name: string;
+        difficulty: string;
+        type: string;
+        gym: string;
+    } | null;
+}
+
+export default function NewSession() {
+    const [user, setUser] = useState<User>();
+    const [completed, setCompleted] = useState<CompletedClimbRow[]>([]);
+    const [selected, setSelected] = useState<Set<number>>(new Set());
+    const [submitting, setSubmitting] = useState(false);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const load = async () => {
+            const {data: {user}} = await supabaseClient.auth.getUser();
+            if (!user) return;
+            setUser(user);
+            const response = await fetch(`${BACKEND_URL}/climbs/logged/${user.id}`);
+            const data = await response.json();
+            if (data.success) {
+                setCompleted(data.data as CompletedClimbRow[]);
+            }
+        };
+        load();
+    }, []);
+
+    const toggleClimb = (id: number) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id); else next.add(id);
+            return next;
+        });
+    };
+
+    const handleSubmit = async (formData: FormData) => {
+        if (!user) return;
+        setSubmitting(true);
+        const sessionDate = formData.get('sessionDate') as string;
+        const durationRaw = formData.get('durationMin') as string;
+        const notes = (formData.get('notes') as string) ?? '';
+        const payload: SessionInput = {
+            user: user.id,
+            sessionDate: sessionDate,
+            durationMin: durationRaw ? Number(durationRaw) : null,
+            notes: notes,
+            completedClimbIds: Array.from(selected),
+        };
+        const res = await fetch(`${BACKEND_URL}/sessions/new`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(payload),
+        });
+        const data = await res.json();
+        setSubmitting(false);
+        if (data.success) {
+            toast("Session saved", {autoClose: 2000});
+            navigate('/sessions');
+        } else {
+            toast.error("Failed to save session", {autoClose: 2500});
+        }
+    };
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    return (
+        <div className={'new-session-page'}>
+            <h1 style={{background: '#EDCDB7', border: '3px solid black', padding: '6px 10px', fontSize: '28px', margin: '16px'}}>
+                New Session
+            </h1>
+            <ToastContainer className={'toast'}/>
+            <form action={handleSubmit}>
+                <label>
+                    <p>Session date:</p>
+                    <input type="date" name="sessionDate" defaultValue={today} required/>
+                </label>
+
+                <label>
+                    <p>Duration (minutes):</p>
+                    <input type="number" name="durationMin" min={0} placeholder="e.g. 90"/>
+                </label>
+
+                <label>
+                    <p>Notes:</p>
+                    <textarea name="notes" placeholder="How did the session go?"/>
+                </label>
+
+                <label>
+                    <p>Include logged climbs:</p>
+                    <div className={'climb-picker'}>
+                        {completed.length === 0 && (
+                            <p>No logged climbs yet. Log some climbs first, then group them here.</p>
+                        )}
+                        {completed.map((row) => {
+                            const climb = row.climbs;
+                            if (!climb) return null;
+                            return (
+                                <label key={row.id} className={'climb-picker-row'}>
+                                    <input
+                                        type="checkbox"
+                                        checked={selected.has(row.id)}
+                                        onChange={() => toggleClimb(row.id)}
+                                    />
+                                    <span>{climb.name} — {climb.difficulty} • {climb.type} @ {climb.gym}</span>
+                                </label>
+                            );
+                        })}
+                    </div>
+                </label>
+
+                <button className={'submit-session-button'} type="submit" disabled={submitting}>
+                    {submitting ? 'Saving...' : 'Save Session'}
+                </button>
+            </form>
+            <HomeRow/>
+        </div>
+    );
+}

--- a/frontend/src/pages/sessions.tsx
+++ b/frontend/src/pages/sessions.tsx
@@ -1,0 +1,130 @@
+import "./styles/sessions.css";
+import HomeRow from "../components/HomeRow.tsx";
+import {useEffect, useState} from "react";
+import {useNavigate} from "react-router-dom";
+import type {User} from "@supabase/supabase-js";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import {BACKEND_URL, type SessionRecord} from "../lib/types.ts";
+import {toast, ToastContainer} from "react-toastify";
+
+function formatDate(dateStr: string): string {
+    const [year, month, day] = dateStr.split('-').map(Number);
+    const date = new Date(year, (month ?? 1) - 1, day);
+    return date.toLocaleDateString(undefined, {year: 'numeric', month: 'short', day: 'numeric'});
+}
+
+export default function Sessions() {
+    const [sessions, setSessions] = useState<SessionRecord[]>([]);
+    const [user, setUser] = useState<User>();
+    const [loading, setLoading] = useState(false);
+    const [expandedId, setExpandedId] = useState<number | null>(null);
+    const [expandedDetail, setExpandedDetail] = useState<SessionRecord | null>(null);
+    const navigate = useNavigate();
+
+    const fetchSessions = async (userId: string) => {
+        setLoading(true);
+        const response = await fetch(`${BACKEND_URL}/sessions/${userId}`);
+        const data = await response.json();
+        if (data.success) {
+            setSessions(data.data as SessionRecord[]);
+        } else {
+            toast.error("Failed to load sessions", {autoClose: 2500});
+        }
+        setLoading(false);
+    };
+
+    useEffect(() => {
+        const init = async () => {
+            const {data: {user}} = await supabaseClient.auth.getUser();
+            if (!user) return;
+            setUser(user);
+            await fetchSessions(user.id);
+        };
+        init();
+    }, []);
+
+    const handleToggleExpand = async (sessionId: number) => {
+        if (expandedId === sessionId) {
+            setExpandedId(null);
+            setExpandedDetail(null);
+            return;
+        }
+        setExpandedId(sessionId);
+        setExpandedDetail(null);
+        const response = await fetch(`${BACKEND_URL}/sessions/detail/${sessionId}`);
+        const data = await response.json();
+        if (data.success) {
+            setExpandedDetail(data.data as SessionRecord);
+        } else {
+            toast.error("Failed to load session detail", {autoClose: 2500});
+        }
+    };
+
+    const handleDelete = async (sessionId: number) => {
+        const response = await fetch(`${BACKEND_URL}/sessions/${sessionId}`, {method: "DELETE"});
+        const data = await response.json();
+        if (data.success) {
+            toast("Session deleted", {autoClose: 2000});
+            if (user) await fetchSessions(user.id);
+            if (expandedId === sessionId) {
+                setExpandedId(null);
+                setExpandedDetail(null);
+            }
+        } else {
+            toast.error("Failed to delete session", {autoClose: 2500});
+        }
+    };
+
+    return (
+        <div className={'sessions-page'}>
+            <h1>Session History</h1>
+            <ToastContainer className={'toast'}/>
+            <button className={'new-session-button'} onClick={() => navigate('/sessions/new')}>
+                + New Session
+            </button>
+
+            <div className={'sessions-list'}>
+                {sessions.length > 0 ? sessions.map((s) => (
+                    <div key={s.id} className={'session-card'}>
+                        <div className={'session-card-header'}>
+                            <span className={'session-card-date'}>{formatDate(s.session_date)}</span>
+                            <span className={'session-card-meta'}>
+                                {s.duration_min != null ? `${s.duration_min} min` : 'No duration'}
+                            </span>
+                        </div>
+                        {s.notes && <div className={'session-card-notes'}>{s.notes}</div>}
+                        {expandedId === s.id && (
+                            <div>
+                                {expandedDetail === null && <p>Loading climbs...</p>}
+                                {expandedDetail?.session_climbs?.length === 0 && (
+                                    <p>No climbs logged for this session.</p>
+                                )}
+                                {expandedDetail?.session_climbs?.map((sc) => {
+                                    const climb = sc.completed_climbs?.climbs;
+                                    if (!climb) return null;
+                                    return (
+                                        <div key={sc.id} className={'session-climb-row'}>
+                                            <span>{climb.name}</span>
+                                            <span>{climb.difficulty} • {climb.type}</span>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+                        <div className={'session-card-actions'}>
+                            <button onClick={() => handleToggleExpand(s.id)}>
+                                {expandedId === s.id ? 'Hide climbs' : 'View climbs'}
+                            </button>
+                            <button className={'danger'} onClick={() => handleDelete(s.id)}>
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+                )) : (loading ? <p className={'empty-state'}>Loading...</p> :
+                    <p className={'empty-state'}>No sessions yet. Tap "+ New Session" to log one.</p>)}
+            </div>
+
+            <HomeRow/>
+        </div>
+    );
+}

--- a/frontend/src/pages/styles/homerow.css
+++ b/frontend/src/pages/styles/homerow.css
@@ -26,6 +26,13 @@
     align-items: center;
 }
 
+.sessions-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 10vw;
+}
+
 .profile-button {
     display: flex;
     flex-direction: row;
@@ -62,6 +69,10 @@
     }
 
     .add-button {
+        margin-left: 20px;
+    }
+
+    .sessions-button {
         margin-left: 20px;
     }
 

--- a/frontend/src/pages/styles/sessions.css
+++ b/frontend/src/pages/styles/sessions.css
@@ -1,0 +1,190 @@
+.sessions-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 16px;
+    padding-bottom: 96px;
+}
+
+.sessions-page h1 {
+    background-color: #EDCDB7;
+    padding: 6px 10px;
+    border: 3px solid black;
+    font-size: 28px;
+    margin: 16px;
+}
+
+.sessions-list {
+    width: 100%;
+    max-width: 720px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.session-card {
+    border: 3px solid black;
+    border-radius: 16px;
+    background-color: #FFF6EE;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.session-card-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.session-card-date {
+    font-weight: bold;
+    font-size: 18px;
+}
+
+.session-card-meta {
+    font-size: 14px;
+    color: #333;
+}
+
+.session-card-notes {
+    font-style: italic;
+    margin-top: 4px;
+}
+
+.session-card-actions {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    margin-top: 6px;
+}
+
+.session-card-actions button {
+    border: 2px solid black;
+    border-radius: 12px;
+    background-color: #EDCDB7;
+    padding: 4px 10px;
+    cursor: pointer;
+}
+
+.session-card-actions button.danger {
+    background-color: #F4A6A6;
+}
+
+.new-session-button {
+    border: 3px solid black;
+    border-radius: 16px;
+    background-color: #EDCDB7;
+    padding: 8px 16px;
+    margin-bottom: 12px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.session-climb-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 4px 0;
+    border-top: 1px dashed #999;
+}
+
+.session-climb-row:first-of-type {
+    border-top: none;
+}
+
+.new-session-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 16px;
+    margin-bottom: 96px;
+}
+
+.new-session-page form {
+    width: 100%;
+    max-width: 720px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+}
+
+.new-session-page label {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 8px;
+}
+
+.new-session-page label p {
+    font-weight: bold;
+    margin: 12px 0 4px 0;
+}
+
+.new-session-page input,
+.new-session-page textarea {
+    border: 2px solid black;
+    border-radius: 16px;
+    outline: none;
+    background-color: #ECEDED;
+    padding: 6px 10px;
+    width: 100%;
+    font-family: inherit;
+}
+
+.new-session-page textarea {
+    resize: vertical;
+    min-height: 80px;
+}
+
+.climb-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: 320px;
+    overflow-y: auto;
+    border: 2px solid black;
+    border-radius: 16px;
+    padding: 8px;
+    background-color: #FFF6EE;
+}
+
+.climb-picker-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    padding: 6px;
+    border-bottom: 1px dashed #aaa;
+}
+
+.climb-picker-row:last-child {
+    border-bottom: none;
+}
+
+.climb-picker-row input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+}
+
+.submit-session-button {
+    border: 2px solid black;
+    border-radius: 16px;
+    padding: 8px 10px;
+    margin: 24px 0;
+    width: 100%;
+    background-color: #EDCDB7;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.submit-session-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.empty-state {
+    margin-top: 24px;
+    color: #555;
+}

--- a/migrations/0001_session_logger.sql
+++ b/migrations/0001_session_logger.sql
@@ -1,0 +1,31 @@
+-- Session logger: groups completed climbs into a dated session with duration and notes.
+--
+-- Tables:
+--   sessions             - one row per session owned by a user
+--   session_climbs       - join row linking a completed_climbs entry to a session
+--
+-- Run order: apply this file in Supabase SQL editor (or via `supabase db push`)
+-- against the same schema that hosts `climbs` and `completed_climbs`.
+
+create table if not exists sessions (
+    id              bigserial primary key,
+    climber         uuid not null,
+    session_date    date not null,
+    duration_min    integer,
+    notes           text,
+    created_at      timestamptz not null default now()
+);
+
+create index if not exists sessions_climber_idx on sessions (climber);
+create index if not exists sessions_climber_date_idx on sessions (climber, session_date desc);
+
+create table if not exists session_climbs (
+    id                   bigserial primary key,
+    session_id           bigint not null references sessions(id) on delete cascade,
+    completed_climb_id   bigint not null,
+    created_at           timestamptz not null default now(),
+    unique (session_id, completed_climb_id)
+);
+
+create index if not exists session_climbs_session_idx on session_climbs (session_id);
+create index if not exists session_climbs_completed_idx on session_climbs (completed_climb_id);


### PR DESCRIPTION
## Summary

Adds a **session logger** feature so climbers can bundle their completed climbs into a session record that carries a date, an optional duration in minutes, and free-form notes.

- **Backend** (`backend/src/routes.ts`): four new routes — `GET /sessions/:uuid`, `GET /sessions/detail/:id`, `POST /sessions/new`, `DELETE /sessions/:id` — all follow the existing `packageResponse` pattern.
- **Database** (`migrations/0001_session_logger.sql`): two new tables — `sessions` (user uuid, session_date, duration_min, notes) and `session_climbs` (join to `completed_climbs`, cascading delete). **Not applied** — needs to be run manually in Supabase.
- **Frontend**: new `/sessions` history page and `/sessions/new` composer page, wired into the Router in `pages/main.tsx` and a new journal icon in `HomeRow`. Users can view their sessions (expand to see the grouped climbs), create a new one by picking among their already-logged climbs, and delete a session.
- **Types** (`frontend/src/lib/types.ts`): added `SessionInput` and `SessionRecord` interfaces shared by backend and frontend.

## Why

The app already lets climbers log individual climbs, but there is no way to reason about a *workout* — how long a session lasted, what climbs were attempted in a single visit, and how it felt. Grouping climbs into sessions lets users track patterns over time (duration, volume, gym) without changing how individual climbs are logged.

## Follow-ups

- **Run the migration.** `migrations/0001_session_logger.sql` must be applied to the Supabase instance before these routes will work. The app has no migration tool committed, so this is a manual step (Supabase SQL editor or `supabase db push`).
- **RLS policies.** Matching the existing tables, this PR adds no Row Level Security policies on `sessions` / `session_climbs`. If RLS is enabled project-wide, corresponding policies keyed on `auth.uid() = climber` will need to be added.
- **Pre-existing build status.** `main` currently does not pass `npm run build` on either workspace (backend has 25 pre-existing TS errors; frontend has pre-existing TS errors and a Vite/lightningcss syntax error from a stray `.` in `profile.css:45`). This PR does **not** add new TypeScript or ESLint errors to any file it touches — verified by filtering build and lint output for the new/modified paths. Cleaning up the pre-existing failures is intentionally out of scope.
- **No env vars or secrets needed** beyond what `main` already expects (`SUPABASE_URL`, `SUPABASE_KEY`, `FRONTEND_URL`).

## Test plan

- [ ] Apply `migrations/0001_session_logger.sql` to a dev Supabase instance
- [ ] `POST /sessions/new` with a valid user and a list of completed_climb ids — verify session row + join rows inserted
- [ ] `GET /sessions/:uuid` returns sessions in descending date order
- [ ] `GET /sessions/detail/:id` returns the session with nested climbs
- [ ] `DELETE /sessions/:id` removes the session and its join rows (cascade)
- [ ] From `/home`, tap the Sessions icon → sees `/sessions` page, tap "+ New Session" → can save with any subset of logged climbs
- [ ] Expand a session card → climbs show; delete a session → it disappears