### PR TITLE
feat: leaderboard: 30-day global climbs leaderboard

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -11,7 +11,8 @@ import {
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
+    BOULDER_GRADES, type Log,
+    type LeaderboardEntry
 } from "../../frontend/src/lib/types.ts";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
@@ -68,6 +69,13 @@ export function setupRoutes(server: FastifyInstance) {
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
         res.status(code).send(reply);
+    });
+
+    server.get<{
+        Reply: BaseReply<LeaderboardEntry[]>;
+    }>("/leaderboard", async (_req, res) => {
+        const {reply, code} = await packageResponse(() => handleLeaderboard());
+        return res.status(code).send(reply);
     });
 
     async function handleFeaturedClimbs(): Promise<Task> {
@@ -210,6 +218,72 @@ export function setupRoutes(server: FastifyInstance) {
                 return gradeList.filter(grade => BOULDER_GRADES[grade] <= BOULDER_GRADES[filterGrade]);
             }
         }
+    }
+
+    async function handleLeaderboard(): Promise<Process<LeaderboardEntry[]>> {
+        const thirtyDaysAgo = new Date();
+        thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+        const {data, error} = await server.supabase
+            .from("completed_climbs")
+            .select("climber, created_at")
+            .gte("created_at", thirtyDaysAgo.toISOString());
+
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+
+        const counts = new Map<string, number>();
+        for (const row of data ?? []) {
+            const climber: string | null = (row as {climber?: string}).climber ?? null;
+            if (!climber) continue;
+            counts.set(climber, (counts.get(climber) ?? 0) + 1);
+        }
+
+        const climberIds = [...counts.keys()];
+        const profiles = new Map<string, {name: string | null, avatarUrl: string | null}>();
+
+        const adminAuth = (server.supabase.auth as unknown as {
+            admin?: { getUserById: (id: string) => Promise<{ data: { user: any } | null, error: any }> }
+        }).admin;
+
+        if (adminAuth?.getUserById) {
+            const results = await Promise.all(climberIds.map(async (id) => {
+                try {
+                    const {data: userData, error: userError} = await adminAuth.getUserById(id);
+                    if (userError || !userData?.user) return [id, null] as const;
+                    const meta = (userData.user.user_metadata ?? {}) as Record<string, unknown>;
+                    const name = (meta.name as string | undefined)
+                        ?? (meta.full_name as string | undefined)
+                        ?? (meta.user_name as string | undefined)
+                        ?? (userData.user.email as string | undefined)
+                        ?? null;
+                    const avatarUrl = (meta.avatar_url as string | undefined)
+                        ?? (meta.picture as string | undefined)
+                        ?? null;
+                    return [id, {name, avatarUrl}] as const;
+                } catch {
+                    return [id, null] as const;
+                }
+            }));
+            for (const [id, profile] of results) {
+                if (profile) profiles.set(id, profile);
+            }
+        }
+
+        const entries: LeaderboardEntry[] = climberIds
+            .map((userId) => {
+                const profile = profiles.get(userId);
+                return {
+                    userId,
+                    name: profile?.name ?? null,
+                    avatarUrl: profile?.avatarUrl ?? null,
+                    count: counts.get(userId) ?? 0,
+                };
+            })
+            .sort((a, b) => b.count - a.count);
+
+        return {success: true, data: entries};
     }
 
     async function handleLog(req: Log): Promise<Task> {

--- a/frontend/src/components/HomeRow.tsx
+++ b/frontend/src/components/HomeRow.tsx
@@ -22,6 +22,14 @@ export default function HomeRow() {
                 </svg>
                 <p>Add Climb</p>
             </div>
+            <div className={'leaderboard-button'} onClick={() => navigate("/leaderboard")}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
+                     className="bi bi-trophy" viewBox="0 0 16 16">
+                    <path
+                        d="M2.5.5A.5.5 0 0 1 3 0h10a.5.5 0 0 1 .5.5q0 .807-.034 1.536a3 3 0 1 1-1.133 5.89c-.79 1.865-1.878 2.777-2.833 3.011v2.173l1.425.356c.194.048.377.135.537.255L13.3 15.1a.5.5 0 0 1-.3.9H3a.5.5 0 0 1-.3-.9l1.838-1.379c.16-.12.343-.207.537-.255L6.5 13.11v-2.173c-.955-.234-2.043-1.146-2.833-3.012a3 3 0 1 1-1.132-5.89A33 33 0 0 1 2.5.5m.099 2.54a2 2 0 0 0 .72 3.935c-.333-1.05-.588-2.346-.72-3.935m10.083 3.935a2 2 0 0 0 .72-3.935c-.133 1.59-.388 2.885-.72 3.935M3.504 1q.01.775.056 1.469c.13 2.028.457 3.546.87 4.667C5.294 9.48 6.484 10 7 10a.5.5 0 0 1 .5.5v2.61a1 1 0 0 1-.757.97l-1.426.356a.5.5 0 0 0-.179.085L4.5 15h7l-.638-.479a.5.5 0 0 0-.18-.085l-1.425-.356a1 1 0 0 1-.757-.97V10.5A.5.5 0 0 1 9 10c.516 0 1.706-.52 2.57-2.864.413-1.12.74-2.64.87-4.667q.045-.694.056-1.469z"/>
+                </svg>
+                <p>Leaderboard</p>
+            </div>
             <div className={'profile-button'} onClick={() => navigate("/profile")}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
                      className="bi bi-person" viewBox="0 0 16 16" >

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,13 @@ export interface Log {
     climb: number;
 }
 
+export interface LeaderboardEntry {
+    userId: string;
+    name: string | null;
+    avatarUrl: string | null;
+    count: number;
+}
+
 export const BACKEND_URL: string = 'http://localhost:8000';
 export const FRONTEND_URL: string = 'http://localhost:5173';
 

--- a/frontend/src/pages/leaderboard.tsx
+++ b/frontend/src/pages/leaderboard.tsx
@@ -1,0 +1,76 @@
+import {useEffect, useState} from "react";
+import HomeRow from "../components/HomeRow.tsx";
+import {BACKEND_URL, type LeaderboardEntry} from "../lib/types.ts";
+import "./styles/leaderboard.css";
+
+export default function Leaderboard() {
+    const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchLeaderboard = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await fetch(`${BACKEND_URL}/leaderboard`);
+                const data = await response.json();
+                if (data.success) {
+                    setEntries(data.data);
+                } else {
+                    setError(data.message ?? "Failed to load leaderboard");
+                }
+            } catch (e) {
+                setError(e instanceof Error ? e.message : "Failed to load leaderboard");
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchLeaderboard();
+    }, []);
+
+    const initials = (name: string | null, userId: string) => {
+        const source = name?.trim() || userId;
+        const parts = source.split(/\s+/).filter(Boolean);
+        if (parts.length === 0) return "?";
+        if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+        return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    };
+
+    return (<>
+        <div className={'leaderboard-page'}>
+            <div className={'leaderboard-heading'}>
+                <h1>Leaderboard</h1>
+                <p className={'leaderboard-subtitle'}>Top climbers by climbs sent in the past 30 days</p>
+            </div>
+
+            <div className={'leaderboard-list'}>
+                {loading && <p>Loading...</p>}
+                {error && !loading && <p className={'leaderboard-error'}>{error}</p>}
+                {!loading && !error && entries.length === 0 && (
+                    <p>No climbs logged in the past 30 days yet.</p>
+                )}
+                {!loading && !error && entries.map((entry, index) => (
+                    <div key={entry.userId} className={`leaderboard-row rank-${Math.min(index + 1, 4)}`}>
+                        <div className={'leaderboard-rank'}>{index + 1}</div>
+                        <div className={'leaderboard-avatar'}>
+                            {entry.avatarUrl ? (
+                                <img src={entry.avatarUrl} alt={`${entry.name ?? 'climber'} avatar`}/>
+                            ) : (
+                                <span className={'avatar-fallback'}>{initials(entry.name, entry.userId)}</span>
+                            )}
+                        </div>
+                        <div className={'leaderboard-name'}>
+                            {entry.name ?? `Climber ${entry.userId.slice(0, 8)}`}
+                        </div>
+                        <div className={'leaderboard-count'}>
+                            <span className={'count-number'}>{entry.count}</span>
+                            <span className={'count-label'}>climb{entry.count === 1 ? '' : 's'}</span>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+        <HomeRow/>
+    </>);
+}

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import Leaderboard from "./leaderboard.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -53,6 +54,14 @@ function Root() {
                 element={
                     <ProtectedRoute session={session}>
                         <Profile/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/leaderboard"
+                element={
+                    <ProtectedRoute session={session}>
+                        <Leaderboard/>
                     </ProtectedRoute>
                 }
             />

--- a/frontend/src/pages/styles/homerow.css
+++ b/frontend/src/pages/styles/homerow.css
@@ -17,7 +17,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-right: 10vw;
+    margin-right: 6vw;
 }
 
 .add-button {
@@ -26,11 +26,18 @@
     align-items: center;
 }
 
+.leaderboard-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 6vw;
+    margin-right: 6vw;
+}
+
 .profile-button {
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-left: 10vw;
 }
 
 .home-row p {
@@ -63,6 +70,11 @@
 
     .add-button {
         margin-left: 20px;
+    }
+
+    .leaderboard-button {
+        margin-left: 20px;
+        margin-right: 0;
     }
 
     .profile-button {

--- a/frontend/src/pages/styles/leaderboard.css
+++ b/frontend/src/pages/styles/leaderboard.css
@@ -1,0 +1,122 @@
+.leaderboard-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 16px;
+    padding-bottom: 96px;
+}
+
+.leaderboard-heading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border: 3px solid black;
+    background-color: #EDCDB7;
+    padding: 12px 24px;
+    margin: 16px 0;
+    text-align: center;
+}
+
+.leaderboard-heading h1 {
+    margin: 0;
+}
+
+.leaderboard-subtitle {
+    margin: 4px 0 0 0;
+    font-size: 0.9rem;
+}
+
+.leaderboard-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    max-width: 600px;
+}
+
+.leaderboard-error {
+    color: #b00020;
+    text-align: center;
+}
+
+.leaderboard-row {
+    display: grid;
+    grid-template-columns: 48px 56px 1fr auto;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border: 3px solid black;
+    background-color: #FAEBD7;
+}
+
+.leaderboard-row.rank-1 {
+    background-color: #FFD86B;
+}
+
+.leaderboard-row.rank-2 {
+    background-color: #DCDCDC;
+}
+
+.leaderboard-row.rank-3 {
+    background-color: #E1A77A;
+}
+
+.leaderboard-rank {
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-align: center;
+}
+
+.leaderboard-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    overflow: hidden;
+    background-color: #EDCDB7;
+    border: 2px solid black;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.leaderboard-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.avatar-fallback {
+    font-weight: 700;
+    font-size: 1rem;
+}
+
+.leaderboard-name {
+    font-size: 1.05rem;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.leaderboard-count {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    line-height: 1;
+}
+
+.count-number {
+    font-size: 1.4rem;
+    font-weight: 700;
+}
+
+.count-label {
+    font-size: 0.75rem;
+    margin-top: 2px;
+}
+
+@media only screen and (min-width: 1500px) {
+    .leaderboard-page {
+        margin-left: 150px;
+    }
+}

--- a/migrations/20260423_completed_climbs_created_at.sql
+++ b/migrations/20260423_completed_climbs_created_at.sql
@@ -1,0 +1,12 @@
+-- Ensures completed_climbs has a created_at timestamp so the leaderboard
+-- endpoint can filter rows logged within the past 30 days. Idempotent so it
+-- is safe to apply against existing databases that already have the column.
+
+ALTER TABLE completed_climbs
+    ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS completed_climbs_created_at_idx
+    ON completed_climbs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS completed_climbs_climber_created_at_idx
+    ON completed_climbs (climber, created_at DESC);


### PR DESCRIPTION
## Summary

Adds a global leaderboard that ranks users by the number of climbs they
have logged in the past 30 days, surfaced as a new bottom-bar entry on
the existing protected pages.

### Backend

- New `GET /leaderboard` endpoint in `backend/src/routes.ts` that:
  - Pulls every `completed_climbs` row with `created_at >= now() - 30d`.
  - Aggregates counts per `climber` UUID in TypeScript (no DB function
    required).
  - Hydrates each climber via `supabase.auth.admin.getUserById` to pull
    `name` / `avatar_url` from `user_metadata`, gracefully falling back
    to a UUID-only entry when admin auth is unavailable.
  - Returns a sorted `LeaderboardEntry[]` through the existing
    `packageResponse` envelope.

### Frontend

- New `frontend/src/pages/leaderboard.tsx` page rendering an avatar +
  name + count list with podium colors for ranks 1–3 and an initials
  fallback when no avatar is present.
- Matching stylesheet at `frontend/src/pages/styles/leaderboard.css`
  following the existing `pages/styles/*.css` convention (Tailwind is in
  the dependency list but not actually wired up in this repo).
- New protected route `/leaderboard` registered in
  `frontend/src/pages/main.tsx` and a fourth bottom-bar entry in
  `HomeRow.tsx` (with adjusted spacing in `homerow.css`).
- Added `LeaderboardEntry` to `frontend/src/lib/types.ts` so frontend
  and backend share the response shape.

### Migration

- `migrations/20260423_completed_climbs_created_at.sql` ensures
  `completed_climbs.created_at` exists (with `DEFAULT now()`) and adds
  supporting indexes. The migration is idempotent — safe to apply even
  if the column already exists.

## Assumptions / follow-ups

- **Service-role key**: the leaderboard hydrates user names/avatars
  through `supabase.auth.admin.getUserById`, which requires the backend
  `SUPABASE_KEY` env var to be the project's service-role key. If only
  an anon key is configured the endpoint still works — entries fall
  back to `Climber <uuid prefix>` with no avatar. No new env vars are
  introduced.
- **Run the migration** before deploying so the 30-day filter has a
  timestamp to filter against.
- **Pre-existing build errors**: both `backend && npm run build` and
  `frontend && npm run build` already fail on `main` with TypeScript
  errors in untouched files. This PR introduces no new errors in files
  it owns; the only delta in the frontend error count is a new
  occurrence of the pre-existing `ProtectedRoute` `Session | null`
  typing issue, identical to the four existing routes. Cleaning up
  those is out of scope for this PR.
- **No write paths**: the endpoint is read-only and unauthenticated —
  it relies on the same posture as `/featured` / `/climbs`. If the team
  wants the leaderboard gated, that can be a follow-up.

## Test plan

- [ ] Apply `migrations/20260423_completed_climbs_created_at.sql` to
      the Supabase project.
- [ ] Confirm `SUPABASE_KEY` is the service-role key (or accept
      avatar-less fallback).
- [ ] `curl http://localhost:8000/leaderboard` returns the expected
      `{ success: true, data: [...] }` payload sorted desc by count.
- [ ] Visit `/leaderboard` in the app, verify avatars + counts render
      and the new bottom-bar entry navigates correctly.
- [ ] Log a climb, refresh the leaderboard, and confirm the count
      increments for the climbing user.