### PR TITLE
feat: snake-game: add hidden /snake easter egg

### DIFF
--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import Snake from "./snake.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -56,6 +57,7 @@ function Root() {
                     </ProtectedRoute>
                 }
             />
+            <Route path="/snake" element={<Snake/>}/>
         </Routes>
     </BrowserRouter>);
 

--- a/frontend/src/pages/snake.tsx
+++ b/frontend/src/pages/snake.tsx
@@ -1,0 +1,224 @@
+import {useCallback, useEffect, useRef, useState} from "react";
+import "./styles/snake.css";
+
+const BOARD_SIZE = 20;
+const CELL_SIZE = 20;
+const TICK_MS = 110;
+const HIGH_SCORE_KEY = "clapp.snake.highScore";
+
+type Point = { x: number; y: number };
+type Direction = "up" | "down" | "left" | "right";
+
+const DIRECTION_VECTORS: Record<Direction, Point> = {
+    up: {x: 0, y: -1},
+    down: {x: 0, y: 1},
+    left: {x: -1, y: 0},
+    right: {x: 1, y: 0},
+};
+
+const OPPOSITES: Record<Direction, Direction> = {
+    up: "down",
+    down: "up",
+    left: "right",
+    right: "left",
+};
+
+const INITIAL_SNAKE: Point[] = [
+    {x: 10, y: 10},
+    {x: 9, y: 10},
+    {x: 8, y: 10},
+];
+
+function randomFoodPosition(snake: Point[]): Point {
+    while (true) {
+        const candidate = {
+            x: Math.floor(Math.random() * BOARD_SIZE),
+            y: Math.floor(Math.random() * BOARD_SIZE),
+        };
+        if (!snake.some((segment) => segment.x === candidate.x && segment.y === candidate.y)) {
+            return candidate;
+        }
+    }
+}
+
+function readStoredHighScore(): number {
+    if (typeof window === "undefined") return 0;
+    const stored = window.localStorage.getItem(HIGH_SCORE_KEY);
+    if (!stored) return 0;
+    const parsed = parseInt(stored, 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export default function Snake() {
+    const [snake, setSnake] = useState<Point[]>(INITIAL_SNAKE);
+    const [direction, setDirection] = useState<Direction>("right");
+    const [food, setFood] = useState<Point>(() => randomFoodPosition(INITIAL_SNAKE));
+    const [score, setScore] = useState(0);
+    const [highScore, setHighScore] = useState<number>(readStoredHighScore);
+    const [gameOver, setGameOver] = useState(false);
+    const [paused, setPaused] = useState(false);
+
+    const pendingDirectionRef = useRef<Direction>("right");
+    const directionRef = useRef<Direction>("right");
+
+    const resetGame = useCallback(() => {
+        setSnake(INITIAL_SNAKE);
+        setFood(randomFoodPosition(INITIAL_SNAKE));
+        setDirection("right");
+        directionRef.current = "right";
+        pendingDirectionRef.current = "right";
+        setScore(0);
+        setGameOver(false);
+        setPaused(false);
+    }, []);
+
+    useEffect(() => {
+        const handleKey = (event: KeyboardEvent) => {
+            const key = event.key;
+            let next: Direction | null = null;
+            if (key === "ArrowUp" || key === "w" || key === "W") next = "up";
+            else if (key === "ArrowDown" || key === "s" || key === "S") next = "down";
+            else if (key === "ArrowLeft" || key === "a" || key === "A") next = "left";
+            else if (key === "ArrowRight" || key === "d" || key === "D") next = "right";
+
+            if (next) {
+                event.preventDefault();
+                if (next !== OPPOSITES[directionRef.current]) {
+                    pendingDirectionRef.current = next;
+                }
+                return;
+            }
+
+            if (key === " " || key === "Enter") {
+                event.preventDefault();
+                if (gameOver) {
+                    resetGame();
+                } else {
+                    setPaused((p) => !p);
+                }
+            }
+        };
+        window.addEventListener("keydown", handleKey);
+        return () => window.removeEventListener("keydown", handleKey);
+    }, [gameOver, resetGame]);
+
+    useEffect(() => {
+        if (gameOver || paused) return;
+        const interval = window.setInterval(() => {
+            setSnake((prev) => {
+                const nextDirection = pendingDirectionRef.current;
+                directionRef.current = nextDirection;
+                setDirection(nextDirection);
+
+                const vector = DIRECTION_VECTORS[nextDirection];
+                const head = prev[0];
+                const newHead: Point = {x: head.x + vector.x, y: head.y + vector.y};
+
+                if (
+                    newHead.x < 0 ||
+                    newHead.x >= BOARD_SIZE ||
+                    newHead.y < 0 ||
+                    newHead.y >= BOARD_SIZE
+                ) {
+                    setGameOver(true);
+                    return prev;
+                }
+
+                const ateFood = newHead.x === food.x && newHead.y === food.y;
+                const body = ateFood ? prev : prev.slice(0, -1);
+
+                if (body.some((seg) => seg.x === newHead.x && seg.y === newHead.y)) {
+                    setGameOver(true);
+                    return prev;
+                }
+
+                const nextSnake = [newHead, ...body];
+
+                if (ateFood) {
+                    setFood(randomFoodPosition(nextSnake));
+                    setScore((s) => {
+                        const next = s + 1;
+                        setHighScore((hs) => {
+                            if (next > hs) {
+                                window.localStorage.setItem(HIGH_SCORE_KEY, String(next));
+                                return next;
+                            }
+                            return hs;
+                        });
+                        return next;
+                    });
+                }
+
+                return nextSnake;
+            });
+        }, TICK_MS);
+        return () => window.clearInterval(interval);
+    }, [food, gameOver, paused]);
+
+    const boardPixelSize = BOARD_SIZE * CELL_SIZE;
+
+    return (
+        <div className="snake-page">
+            <h1 className="snake-title">Snake</h1>
+            <div className="snake-scoreboard">
+                <span>Score: {score}</span>
+                <span>High Score: {highScore}</span>
+            </div>
+            <div
+                className="snake-board"
+                style={{width: boardPixelSize, height: boardPixelSize}}
+                role="grid"
+                aria-label="Snake game board"
+            >
+                {snake.map((segment, index) => (
+                    <div
+                        key={`${segment.x}-${segment.y}-${index}`}
+                        className={`snake-segment${index === 0 ? " snake-head" : ""}`}
+                        style={{
+                            left: segment.x * CELL_SIZE,
+                            top: segment.y * CELL_SIZE,
+                            width: CELL_SIZE,
+                            height: CELL_SIZE,
+                        }}
+                    />
+                ))}
+                <div
+                    className="snake-food"
+                    style={{
+                        left: food.x * CELL_SIZE,
+                        top: food.y * CELL_SIZE,
+                        width: CELL_SIZE,
+                        height: CELL_SIZE,
+                    }}
+                />
+                {(gameOver || paused) && (
+                    <div className="snake-overlay">
+                        {gameOver ? (
+                            <>
+                                <div className="snake-overlay-title">Game Over</div>
+                                <div className="snake-overlay-sub">Press Enter to play again</div>
+                            </>
+                        ) : (
+                            <>
+                                <div className="snake-overlay-title">Paused</div>
+                                <div className="snake-overlay-sub">Press Space to resume</div>
+                            </>
+                        )}
+                    </div>
+                )}
+            </div>
+            <div className="snake-controls">
+                <button onClick={resetGame}>Restart</button>
+                <button
+                    onClick={() => setPaused((p) => !p)}
+                    disabled={gameOver}
+                >
+                    {paused ? "Resume" : "Pause"}
+                </button>
+            </div>
+            <p className="snake-hint">
+                Arrow keys or WASD to move · Space to pause · Direction: {direction}
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/pages/styles/snake.css
+++ b/frontend/src/pages/styles/snake.css
@@ -1,0 +1,102 @@
+.snake-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 24px 16px 48px;
+    gap: 16px;
+    font-family: system-ui, sans-serif;
+}
+
+.snake-title {
+    margin: 0;
+    font-size: 32px;
+    font-weight: 700;
+    color: #1a1a1a;
+}
+
+.snake-scoreboard {
+    display: flex;
+    gap: 24px;
+    font-size: 18px;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+
+.snake-board {
+    position: relative;
+    background-color: #f0e5d1;
+    border: 3px solid #1a1a1a;
+    border-radius: 6px;
+    overflow: hidden;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.snake-segment {
+    position: absolute;
+    background-color: #2f7a3d;
+    border: 1px solid #1e5128;
+    box-sizing: border-box;
+}
+
+.snake-head {
+    background-color: #3fa255;
+    border-color: #1e5128;
+}
+
+.snake-food {
+    position: absolute;
+    background-color: #d94141;
+    border: 1px solid #7a1f1f;
+    border-radius: 50%;
+    box-sizing: border-box;
+}
+
+.snake-overlay {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.55);
+    color: #ffffff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    text-align: center;
+}
+
+.snake-overlay-title {
+    font-size: 28px;
+    font-weight: 700;
+}
+
+.snake-overlay-sub {
+    font-size: 14px;
+    opacity: 0.85;
+}
+
+.snake-controls {
+    display: flex;
+    gap: 12px;
+}
+
+.snake-controls button {
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: 2px solid #1a1a1a;
+    background-color: #edcdb7;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.snake-controls button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.snake-hint {
+    margin: 0;
+    color: #444444;
+    font-size: 13px;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary

Adds a hidden Snake game accessible at `/snake` as a fun easter egg. Fully playable with arrow keys (or WASD), with a high score persisted in `localStorage`.

## What changed

- New page `frontend/src/pages/snake.tsx` — classic Snake on a 20x20 grid, rendered with absolutely-positioned divs inside a bordered board. Arrow keys / WASD steer; Space pauses; Enter restarts after Game Over. Direction reversal is blocked within a single tick so you can't die by pressing the opposite direction mid-segment.
- New stylesheet `frontend/src/pages/styles/snake.css` matching the existing plain-CSS convention used by the other pages.
- New route wired into `frontend/src/pages/main.tsx`: `<Route path="/snake" element={<Snake/>}/>`. The route is **public** (no `ProtectedRoute`) so it works as a discoverable easter egg without requiring a Supabase session.

## Why

Lightweight, self-contained fun. No backend, no migrations, no new dependencies, no auth coupling — just React + one CSS file. High score stored under the `clapp.snake.highScore` localStorage key.

## Assumptions / notes

- Public route by design — an easter egg behind a login prompt isn't much of an easter egg. Easy to move inside `ProtectedRoute` if that's preferred.
- Used plain CSS (matching the rest of the project's pages) rather than Tailwind utility classes. The project has Tailwind v4 installed but the existing pages are styled with per-page `.css` files, so I followed that pattern.
- Tick interval is 110ms; board is 20x20 cells at 20px each. Tunable via constants at the top of the file.
- No new dependencies added.

## Follow-ups

- None required. No env vars, no migrations, no backend changes.
- If you'd like, a small unobtrusive link from the footer/profile page could make the easter egg more discoverable — left out intentionally to keep it hidden.

## Build / lint status

- `frontend` — the new files are TypeScript- and ESLint-clean (`npx eslint src/pages/snake.tsx` passes; `tsc` reports no errors in `snake.tsx` or the route addition in `main.tsx`). The `npm run build` pipeline surfaces **pre-existing** type errors in unrelated files (`ClimbElement.tsx`, `FilterClimbs.tsx`, `SearchBar.tsx`, `home.tsx`, `newclimb.tsx`, and the `ProtectedRoute session` typing in `main.tsx`) that exist on `main` before this PR; those were left untouched per the focused-diff guideline.
- `backend` — not modified. `npm run build` on `backend` also has pre-existing errors on `main` unrelated to this change.

## Test plan

- [ ] Visit `/snake` — board and score render, snake moves right by default.
- [ ] Arrow keys / WASD steer the snake; opposite-direction inputs are ignored mid-tick.
- [ ] Eating food grows the snake and increments the score.
- [ ] Colliding with wall or self triggers Game Over overlay.
- [ ] Pressing Space toggles pause; pressing Enter after Game Over restarts.
- [ ] High score persists across page reloads (stored under `clapp.snake.highScore` in `localStorage`).