### PR TITLE
feat: weather widget on home page with outdoor climbing verdict

### DIFF
--- a/frontend/src/components/WeatherWidget.tsx
+++ b/frontend/src/components/WeatherWidget.tsx
@@ -1,0 +1,163 @@
+import {useEffect, useState} from "react";
+import "../pages/styles/weatherwidget.css";
+
+interface WeatherData {
+    temperature: number;
+    apparentTemperature: number;
+    precipitation: number;
+    windSpeed: number;
+    weatherCode: number;
+}
+
+interface ClimbingVerdict {
+    good: boolean;
+    label: string;
+    reason: string;
+}
+
+const WEATHER_CODE_LABELS: Record<number, string> = {
+    0: "Clear sky",
+    1: "Mainly clear",
+    2: "Partly cloudy",
+    3: "Overcast",
+    45: "Fog",
+    48: "Depositing rime fog",
+    51: "Light drizzle",
+    53: "Moderate drizzle",
+    55: "Dense drizzle",
+    56: "Light freezing drizzle",
+    57: "Dense freezing drizzle",
+    61: "Slight rain",
+    63: "Moderate rain",
+    65: "Heavy rain",
+    66: "Light freezing rain",
+    67: "Heavy freezing rain",
+    71: "Slight snow",
+    73: "Moderate snow",
+    75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight rain showers",
+    81: "Moderate rain showers",
+    82: "Violent rain showers",
+    85: "Slight snow showers",
+    86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with slight hail",
+    99: "Thunderstorm with heavy hail",
+};
+
+function describeWeather(code: number): string {
+    return WEATHER_CODE_LABELS[code] ?? "Unknown conditions";
+}
+
+function evaluateClimbing(weather: WeatherData): ClimbingVerdict {
+    const {temperature, precipitation, windSpeed, weatherCode} = weather;
+
+    if (precipitation > 0.1 || (weatherCode >= 51 && weatherCode <= 99)) {
+        return {good: false, label: "Not great", reason: "Wet rock — best to wait it out or hit the gym."};
+    }
+    if (temperature < 2) {
+        return {good: false, label: "Too cold", reason: "Freezing temps make holds painful and risky."};
+    }
+    if (temperature > 32) {
+        return {good: false, label: "Too hot", reason: "Skin and friction suffer in the heat."};
+    }
+    if (windSpeed > 40) {
+        return {good: false, label: "Too windy", reason: "High winds make belaying and rope work sketchy."};
+    }
+    if (temperature >= 8 && temperature <= 22 && windSpeed < 25) {
+        return {good: true, label: "Send weather", reason: "Cool, dry, and calm — prime conditions."};
+    }
+    return {good: true, label: "Good to go", reason: "Conditions look workable for outdoor climbing."};
+}
+
+export default function WeatherWidget() {
+    const [weather, setWeather] = useState<WeatherData | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!("geolocation" in navigator)) {
+            setError("Geolocation is not supported by your browser.");
+            setLoading(false);
+            return;
+        }
+
+        const fetchWeather = async (latitude: number, longitude: number) => {
+            try {
+                const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,apparent_temperature,precipitation,wind_speed_10m,weather_code&timezone=auto`;
+                const response = await fetch(url);
+                if (!response.ok) {
+                    throw new Error(`Weather request failed: ${response.status}`);
+                }
+                const data = await response.json();
+                const current = data.current;
+                setWeather({
+                    temperature: current.temperature_2m,
+                    apparentTemperature: current.apparent_temperature,
+                    precipitation: current.precipitation,
+                    windSpeed: current.wind_speed_10m,
+                    weatherCode: current.weather_code,
+                });
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "Failed to load weather.");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                fetchWeather(position.coords.latitude, position.coords.longitude);
+            },
+            (geoError) => {
+                setError(
+                    geoError.code === geoError.PERMISSION_DENIED
+                        ? "Location permission denied — enable it for a climbing forecast."
+                        : "Couldn't read your location."
+                );
+                setLoading(false);
+            },
+            {timeout: 10000, maximumAge: 5 * 60 * 1000}
+        );
+    }, []);
+
+    if (loading) {
+        return (
+            <div className={"weather-widget loading"}>
+                <p>Checking the weather…</p>
+            </div>
+        );
+    }
+
+    if (error || !weather) {
+        return (
+            <div className={"weather-widget error"}>
+                <p className={"weather-title"}>Weather unavailable</p>
+                <p className={"weather-detail"}>{error ?? "No data."}</p>
+            </div>
+        );
+    }
+
+    const verdict = evaluateClimbing(weather);
+
+    return (
+        <div className={`weather-widget ${verdict.good ? "good" : "bad"}`}>
+            <div className={"weather-summary"}>
+                <p className={"weather-title"}>{describeWeather(weather.weatherCode)}</p>
+                <p className={"weather-temp"}>{Math.round(weather.temperature)}°C</p>
+            </div>
+            <div className={"weather-meta"}>
+                <span>Feels {Math.round(weather.apparentTemperature)}°C</span>
+                <span>Wind {Math.round(weather.windSpeed)} km/h</span>
+                <span>Precip {weather.precipitation} mm</span>
+            </div>
+            <div className={"weather-verdict"}>
+                <span className={"verdict-label"}>
+                    {verdict.good ? "✓" : "✗"} Outdoor climbing: {verdict.label}
+                </span>
+                <span className={"verdict-reason"}>{verdict.reason}</span>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -7,6 +7,7 @@ import {supabaseClient} from "../util/supabaseClient.ts";
 import type {User} from "@supabase/supabase-js";
 import {BACKEND_URL, type Search} from "../lib/types.ts";
 import FilterClimbs from "../components/FilterClimbs.tsx";
+import WeatherWidget from "../components/WeatherWidget.tsx";
 import {toast, ToastContainer} from "react-toastify";
 
 export default function Home() {
@@ -149,6 +150,7 @@ export default function Home() {
         <SearchBar onSearch={onSearch} onFilter={onFilter} filtering={filtering}/>
         <FilterClimbs filter={filter} onAdvSearch={onAdvSearch}/>
         <ToastContainer className={'toast'}/>
+        <WeatherWidget/>
 
         <div className={"climbs"}>
 

--- a/frontend/src/pages/styles/weatherwidget.css
+++ b/frontend/src/pages/styles/weatherwidget.css
@@ -1,0 +1,85 @@
+.weather-widget {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background-color: #EDCDB7;
+    border: 2px black solid;
+    border-radius: 16px;
+    padding: 12px 16px;
+    margin: 80px 16px 0;
+    width: min(420px, calc(100% - 32px));
+    box-sizing: border-box;
+    z-index: 2;
+}
+
+.weather-widget.good {
+    background-color: #CDEDB7;
+}
+
+.weather-widget.bad {
+    background-color: #EDB7B7;
+}
+
+.weather-widget.loading,
+.weather-widget.error {
+    background-color: #EDCDB7;
+}
+
+.weather-summary {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.weather-title {
+    font-weight: 600;
+    font-size: 18px;
+    margin: 0;
+}
+
+.weather-temp {
+    font-weight: 700;
+    font-size: 28px;
+    margin: 0;
+}
+
+.weather-meta {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 14px;
+    opacity: 0.85;
+}
+
+.weather-verdict {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border-top: 1px solid rgba(0, 0, 0, 0.25);
+    padding-top: 8px;
+}
+
+.verdict-label {
+    font-weight: 700;
+    font-size: 16px;
+}
+
+.verdict-reason {
+    font-size: 14px;
+    opacity: 0.85;
+}
+
+.weather-detail {
+    font-size: 14px;
+    margin: 0;
+    opacity: 0.85;
+}
+
+@media only screen and (min-width: 768px) {
+    .weather-widget {
+        width: 500px;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a weather widget to the home page that shows current conditions for the user's location and a quick verdict on whether it's a good day for outdoor climbing.

## What changed

- New component `frontend/src/components/WeatherWidget.tsx` that:
  - Requests browser geolocation (cached for 5 min)
  - Calls Open-Meteo's free `/v1/forecast` endpoint (no API key required) for current temperature, apparent temperature, precipitation, wind, and weather code
  - Computes a verdict using simple heuristics: rain/snow/freezing rock = bad, < 2°C or > 32°C = bad, wind > 40 km/h = bad, the 8–22°C dry-and-calm sweet spot = "Send weather", everything else workable = "Good to go"
  - Displays loading, error, and permission-denied states inline
- New stylesheet `frontend/src/pages/styles/weatherwidget.css` matching the existing tan/border aesthetic; tints green when conditions are good, red when not
- `frontend/src/pages/home.tsx` renders `<WeatherWidget/>` between the search controls and the climb grid

## Why

Outdoor climbers often check the weather before deciding whether to head outside or stay at the gym. Surfacing this directly in the app saves a context switch and complements the existing climb log.

## Assumptions

- Open-Meteo is appropriate as a free, key-less weather source — it's the only API used and is called directly from the browser, so no backend route or env var is needed
- Temperatures and wind speeds are shown in metric (°C, km/h) since Open-Meteo defaults there and the app has no locale/units setting yet
- The widget degrades gracefully when geolocation is denied or unsupported — no fallback location is shown
- Verdict thresholds are deliberately simple; they can be tuned later (e.g. based on rock type, sun aspect, dew-point friction window)

## Out of scope / follow-ups

- No backend route, no DB migration, no new env vars
- A future PR could add a multi-day forecast (Open-Meteo also returns `daily`), a "best window this week" picker, or per-gym crag presets so users without geolocation still get a useful answer

## Test plan

- [ ] Run `cd frontend && npm run dev`, sign in, open `/home`, accept the location prompt, confirm the widget renders with current conditions and a verdict
- [ ] Deny the location prompt and confirm the widget shows the permission-denied message instead of crashing
- [ ] Throttle the network in devtools and confirm the loading state appears

## Notes for reviewer

The repo's `tsc -b` and `eslint .` both fail on `main` due to pre-existing issues in unrelated files (counts unchanged: 23 TS errors, 14 lint errors before and after this PR). I did not touch those files. The new component itself is type-clean and lint-clean.