### PR TITLE
feat: add 'Export my climbs' button on profile

### DIFF
--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -6,6 +6,8 @@ import type {User} from "@supabase/supabase-js";
 import ClimbElement from "../components/ClimbElement.tsx";
 import './styles/profile.css'
 import {BACKEND_URL} from "../lib/types.ts";
+import {climbsToCsv, downloadCsv} from "../util/exportCsv.ts";
+import {toast, ToastContainer} from "react-toastify";
 
 export default function Profile() {
     const [user, setUser] = useState<User>();
@@ -47,6 +49,19 @@ export default function Profile() {
 
     const avatarUrl = user?.user_metadata?.avatar_url;
     const userName = user?.user_metadata?.name;
+
+    const handleExport = () => {
+        if (climbs.length === 0) {
+            toast.error("No climbs to export", {autoClose: 2500});
+            return;
+        }
+        const csv = climbsToCsv(climbs);
+        const stamp = new Date().toISOString().slice(0, 10);
+        const safeName = (userName ?? "climbs").toString().replace(/[^a-z0-9_-]+/gi, "_");
+        downloadCsv(`${safeName}_climbs_${stamp}.csv`, csv);
+        toast("Exported climbs to CSV", {autoClose: 2500});
+    };
+
     return (<>
             <div className={'profile-page'}>
 
@@ -55,6 +70,13 @@ export default function Profile() {
                         <img className={"profile-picture"} src={avatarUrl} alt={"user's profile picture"}/>
                         <h1>{userName}</h1>
                     </div>
+                    <button
+                        className={"export-climbs-button"}
+                        onClick={handleExport}
+                        disabled={loading || climbs.length === 0}
+                    >
+                        Export my climbs
+                    </button>
                     <h1 className={"completed-climbs"}>Completed Climbs</h1>
                 </div>
 
@@ -70,6 +92,7 @@ export default function Profile() {
                 </div>
 
             </div>
+            <ToastContainer className={'toast'}/>
             <HomeRow/>
         </>
     );

--- a/frontend/src/pages/styles/profile.css
+++ b/frontend/src/pages/styles/profile.css
@@ -14,6 +14,25 @@
     padding: 4px;
     width: fit-content;
 }
+
+.export-climbs-button {
+    border: 3px solid black;
+    background-color: #EDCDB7;
+    padding: 8px 16px;
+    margin-bottom: 12px;
+    font-weight: bold;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.export-climbs-button:hover:not(:disabled) {
+    background-color: #d9b79a;
+}
+
+.export-climbs-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
 .heading{
     display: flex;
     flex-direction: column;

--- a/frontend/src/util/exportCsv.ts
+++ b/frontend/src/util/exportCsv.ts
@@ -1,0 +1,43 @@
+const CSV_COLUMNS: { key: string; header: string }[] = [
+    {key: "name", header: "Name"},
+    {key: "difficulty", header: "Difficulty"},
+    {key: "type", header: "Type"},
+    {key: "color", header: "Color"},
+    {key: "setter", header: "Setter"},
+    {key: "gym", header: "Gym"},
+    {key: "date_set", header: "Date Set"},
+    {key: "date_completed", header: "Date Completed"},
+];
+
+function escapeCell(value: unknown): string {
+    if (value === null || value === undefined) return "";
+    const str = String(value);
+    if (/[",\r\n]/.test(str)) {
+        return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+}
+
+export function climbsToCsv(loggedClimbs: Array<Record<string, unknown>>): string {
+    const header = CSV_COLUMNS.map((c) => c.header).join(",");
+    const rows = loggedClimbs.map((entry) => {
+        const climb = (entry.climbs as Record<string, unknown> | null) ?? {};
+        return CSV_COLUMNS.map(({key}) => {
+            if (key === "date_completed") return escapeCell(entry.created_at ?? entry.date_completed ?? "");
+            return escapeCell(climb[key]);
+        }).join(",");
+    });
+    return [header, ...rows].join("\r\n");
+}
+
+export function downloadCsv(filename: string, csv: string) {
+    const blob = new Blob([`\uFEFF${csv}`], {type: "text/csv;charset=utf-8"});
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

- Adds an **Export my climbs** button on the profile page that downloads the user's logged climbs as a CSV file generated client-side.
- The CSV is built from the already-fetched `completed_climbs` data (no new backend endpoint), using a small helper in `frontend/src/util/exportCsv.ts` that handles quoting/escaping and triggers a browser download via a Blob URL.
- Adds a success/error toast (reusing the existing `react-toastify` setup from the home page) and matching button styles in `profile.css` that fit the existing design.

## What changed

- `frontend/src/util/exportCsv.ts` (new): `climbsToCsv` + `downloadCsv` utilities. CSV columns: Name, Difficulty, Type, Color, Setter, Gym, Date Set, Date Completed.
- `frontend/src/pages/profile.tsx`: renders the new button in the profile heading; disabled while loading or when the user has no climbs.
- `frontend/src/pages/styles/profile.css`: styling for `.export-climbs-button` consistent with `.completed-climbs` / `.user-info`.

## Assumptions

- Export happens entirely client-side using data already loaded from `GET /climbs/logged/:uuid` — no new route, no new DB migration, no env vars.
- Filename format: `<username>_climbs_<YYYY-MM-DD>.csv`, falling back to `climbs_...` when no display name is available.
- CSV is UTF-8 with a BOM and CRLF line endings so it opens cleanly in Excel.
- `Date Completed` is sourced from the `completed_climbs.created_at` column, which the existing API already returns via `select *`.

## Follow-ups

- None required — no migrations to run, no env vars to set.
- Pre-existing TypeScript and ESLint errors in the repo (on `main`) are not fixed by this PR; only the files touched here were kept clean of *new* errors.

## Test plan

- [ ] Load the profile page while signed in with at least one logged climb, click **Export my climbs**, confirm a CSV downloads and opens correctly in a spreadsheet.
- [ ] Confirm the button is disabled for users with no logged climbs and while loading.
- [ ] Verify that climb names containing commas or quotes are correctly escaped in the CSV.