### PR TITLE
feat: image-upload: let setters attach a photo to climbs

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -44,6 +44,14 @@ export function setupRoutes(server: FastifyInstance) {
         res.status(code).send(reply);
     });
 
+    server.get<{
+        Params: { id: string };
+        Reply: any | { error: string };
+    }>("/climbs/:id", async (req, res) => {
+        const {reply: result, code} = await packageResponse(() => handleGetClimb(req.params));
+        return res.status(code).send(result);
+    });
+
     server.patch('/climbs/archive/:id', async (req, res) => {
         const {reply, code} = await packageResponse(() => handleArchive(req.params));
         res.status(code).send(reply);
@@ -93,9 +101,8 @@ export function setupRoutes(server: FastifyInstance) {
 
     }
 
-//TODO: Handle pictures
     async function handleNewClimb(req: Climb): Promise<Task> {
-        const {name, difficulty, type, color, setter, dateSet, gym} = req;
+        const {name, difficulty, type, color, setter, dateSet, gym, picture} = req;
         const {data, error} = await server.supabase.from("climbs").insert([
             {
                 name: name,
@@ -105,10 +112,24 @@ export function setupRoutes(server: FastifyInstance) {
                 setter: setter,
                 date_set: dateSet,
                 gym: gym,
+                picture: picture ?? null,
             }
         ]).select();
         if (error) {
             return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleGetClimb(params: { id?: string }): Promise<Task> {
+        const {id} = params;
+        const {data, error} = await server.supabase.from("climbs")
+            .select("*").eq("id", id).maybeSingle();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        if (!data) {
+            return {success: false, error: new Error("Climb not found"), code: 404};
         }
         return {success: true, data: data};
     }

--- a/frontend/src/components/ClimbElement.tsx
+++ b/frontend/src/components/ClimbElement.tsx
@@ -1,16 +1,28 @@
-import {type Climb, ROUTE_COLORS} from "../lib/types.ts";
+import {ROUTE_COLORS} from "../lib/types.ts";
 import '../pages/styles/climbelement.css'
-import {useState} from "react";
+import {useNavigate} from "react-router-dom";
+
+interface ClimbRow {
+    name: string;
+    type: string;
+    color: string;
+    date_set: string;
+    gym: string;
+    setter: string;
+    difficulty: string;
+    picture?: string | null;
+}
 
 interface ClimbElementProps {
-    jsonClimb: Climb;
+    jsonClimb: ClimbRow;
     climbId: number;
-    onLog: (climb: Climb) => void;
+    onLog: (climb: number) => void;
     isSelected: boolean;
 }
 
 export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: ClimbElementProps) {
-    const climbAdapter = (data) => {
+    const navigate = useNavigate();
+    const climbAdapter = (data: ClimbRow) => {
         return {
             name: data.name,
             type: data.type,
@@ -19,10 +31,10 @@ export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: Cl
             gym: data.gym,
             setter: data.setter,
             difficulty: data.difficulty,
-
+            picture: data.picture,
         }
     };
-    const {name, difficulty, type, color, setter, dateSet, gym} = climbAdapter(jsonClimb);
+    const {name, difficulty, type, color, setter, dateSet, gym, picture} = climbAdapter(jsonClimb);
     const logClimb = () => {
         onLog(climbId);
     }
@@ -33,8 +45,21 @@ export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: Cl
         return `${month}/${day}/${shortYear}`;
     };
 
+    const openDetails = (event: React.MouseEvent) => {
+        event.stopPropagation();
+        navigate(`/climb/${climbId}`);
+    };
+
 
     return (<div className={`climb-container ${isSelected ? 'highlighted' : ''}`} onClick={logClimb}>
+        {picture && (
+            <img
+                className={'climb-thumbnail'}
+                src={picture}
+                alt={`${name} climb`}
+                onClick={openDetails}
+            />
+        )}
         <div className={"climb-left-column"}>
             <h1>{name}</h1>
             <p>Set by: {setter}</p>
@@ -48,6 +73,9 @@ export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: Cl
                 </svg>
                 <p>{gym} • {type}</p>
             </div>
+            <button type={'button'} className={'climb-details-link'} onClick={openDetails}>
+                View details
+            </button>
 
         </div>
         <div className={"climb-right-column"}>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,7 +1,8 @@
-import {Navigate, type Session, useLocation} from 'react-router-dom';
+import {Navigate, useLocation} from 'react-router-dom';
+import type {Session} from '@supabase/supabase-js';
 
 interface ProtectedRouteProps {
-    session: Session;
+    session: Session | null;
     children: React.ReactNode;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,11 +6,13 @@ export interface Climb {
     setter: string;
     dateSet: Date;
     gym: string;
-    picture: string;
+    picture?: string | null;
     archived: boolean;
     claimed: boolean;
 
 }
+
+export const CLIMB_IMAGES_BUCKET = "climb-images";
 
 export interface Search {
     lowerDifficulty: string;

--- a/frontend/src/pages/climbdetail.tsx
+++ b/frontend/src/pages/climbdetail.tsx
@@ -1,0 +1,94 @@
+import {useEffect, useState} from "react";
+import {useNavigate, useParams} from "react-router-dom";
+import {BACKEND_URL, ROUTE_COLORS} from "../lib/types.ts";
+import HomeRow from "../components/HomeRow.tsx";
+import "./styles/climbdetail.css";
+
+interface ClimbRecord {
+    id: number;
+    name: string;
+    difficulty: string;
+    type: string;
+    color: string;
+    setter: string;
+    date_set: string;
+    gym: string;
+    picture?: string | null;
+    archived?: boolean;
+}
+
+export default function ClimbDetail() {
+    const {id} = useParams<{id: string}>();
+    const navigate = useNavigate();
+    const [climb, setClimb] = useState<ClimbRecord | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const fetchClimb = async () => {
+            setLoading(true);
+            try {
+                const response = await fetch(`${BACKEND_URL}/climbs/${id}`);
+                const data = await response.json();
+                if (cancelled) return;
+                if (data.success) {
+                    setClimb(data.data);
+                } else {
+                    setError(data.message || "Failed to load climb");
+                }
+            } catch (err) {
+                if (!cancelled) setError((err as Error).message);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+        fetchClimb();
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    if (loading) return <div className={'climb-detail-page'}><p>Loading…</p><HomeRow/></div>;
+    if (error || !climb) {
+        return (
+            <div className={'climb-detail-page'}>
+                <p>{error ?? "Climb not found"}</p>
+                <button onClick={() => navigate(-1)}>Go back</button>
+                <HomeRow/>
+            </div>
+        );
+    }
+
+    const formatDate = (dateStr?: string) => {
+        if (!dateStr) return "";
+        const [year, month, day] = dateStr.split('-').map(Number);
+        return `${month}/${day}/${year}`;
+    };
+
+    return (
+        <div className={'climb-detail-page'}>
+            <button className={'back-button'} onClick={() => navigate(-1)}>← Back</button>
+            <div className={'climb-detail-card'}>
+                {climb.picture ? (
+                    <img className={'climb-detail-image'} src={climb.picture} alt={`${climb.name} route`}/>
+                ) : (
+                    <div className={'climb-detail-placeholder'}>No photo yet</div>
+                )}
+                <div className={'climb-detail-body'}>
+                    <div className={'climb-detail-heading'}>
+                        <h1>{climb.name}</h1>
+                        <div className={'cooler-circle'} style={{backgroundColor: ROUTE_COLORS[climb.color]}}></div>
+                    </div>
+                    <p><strong>Grade:</strong> {climb.difficulty}</p>
+                    <p><strong>Type:</strong> {climb.type}</p>
+                    <p><strong>Setter:</strong> {climb.setter}</p>
+                    <p><strong>Gym:</strong> {climb.gym}</p>
+                    <p><strong>Set on:</strong> {formatDate(climb.date_set)}</p>
+                    {climb.archived && <p className={'archived-tag'}>Archived</p>}
+                </div>
+            </div>
+            <HomeRow/>
+        </div>
+    );
+}

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import ClimbDetail from "./climbdetail.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -53,6 +54,14 @@ function Root() {
                 element={
                     <ProtectedRoute session={session}>
                         <Profile/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/climb/:id"
+                element={
+                    <ProtectedRoute session={session}>
+                        <ClimbDetail/>
                     </ProtectedRoute>
                 }
             />

--- a/frontend/src/pages/newclimb.tsx
+++ b/frontend/src/pages/newclimb.tsx
@@ -1,23 +1,58 @@
 import "./styles/newclimb.css"
 import HomeRow from "../components/HomeRow.tsx";
-import {BACKEND_URL, BOULDER_GRADES, ROPE_GRADES, ROUTE_COLORS} from "../lib/types.ts";
+import {BACKEND_URL, BOULDER_GRADES, CLIMB_IMAGES_BUCKET, ROPE_GRADES, ROUTE_COLORS} from "../lib/types.ts";
 import {useState} from "react";
 import {toast, ToastContainer} from "react-toastify";
+import {supabaseClient} from "../util/supabaseClient.ts";
 
 export default function NewClimb() {
     const [type, setType] = useState("Boulder");
     const [color, setColor] = useState("Red");
+    const [picture, setPicture] = useState<File | null>(null);
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [uploading, setUploading] = useState(false);
+
+    const onPictureChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+        setPicture(file);
+        setPreviewUrl(file ? URL.createObjectURL(file) : null);
+    };
+
+    const uploadPicture = async (file: File): Promise<string | null> => {
+        const extension = file.name.includes(".") ? file.name.split(".").pop() : "jpg";
+        const path = `${crypto.randomUUID()}.${extension}`;
+        const {error: uploadError} = await supabaseClient.storage
+            .from(CLIMB_IMAGES_BUCKET)
+            .upload(path, file, {contentType: file.type || undefined, upsert: false});
+        if (uploadError) {
+            console.error("Image upload failed", uploadError);
+            toast.error("Image upload failed", {autoClose: 2500});
+            return null;
+        }
+        const {data} = supabaseClient.storage.from(CLIMB_IMAGES_BUCKET).getPublicUrl(path);
+        return data.publicUrl;
+    };
+
     const addClimbAction = async (formData: FormData) => {
+        setUploading(true);
+        let pictureUrl: string | null = null;
+        if (picture) {
+            pictureUrl = await uploadPicture(picture);
+            if (!pictureUrl) {
+                setUploading(false);
+                return;
+            }
+        }
         const newClimb = {
             name: formData.get('name') as string,
             difficulty: formData.get('difficulty') as string,
             type: formData.get('type') as string,
             color: formData.get('color') as string,
             setter: formData.get('setter') as string,
-            dateSet: formData.get('dateSet') as Date,
+            dateSet: formData.get('dateSet') as unknown as Date,
             gym: formData.get('gym') as string,
+            picture: pictureUrl,
         }
-        console.log(newClimb)
         const data = await fetch(`${BACKEND_URL}/climbs/new`, {
             method: "POST",
             headers: {
@@ -28,10 +63,12 @@ export default function NewClimb() {
         const response = await data.json();
         if (response.success) {
             toast("Climb successfully added!", {autoClose: 2500});
+            setPicture(null);
+            setPreviewUrl(null);
         } else {
             toast.error("Failed to Log Climb", {autoClose: 2500});
         }
-
+        setUploading(false);
     };
 
 
@@ -61,8 +98,8 @@ export default function NewClimb() {
             <label>
                 <p>What is the Climb Difficulty:</p>
                 <select name="difficulty" required={true}>
-                    {type === "Boulder" ? (Object.keys(BOULDER_GRADES).map((boulder) => (<option>{boulder}</option>))) :
-                        (Object.keys(ROPE_GRADES).map((grade) => (<option value={grade}>{grade}</option>)))}
+                    {type === "Boulder" ? (Object.keys(BOULDER_GRADES).map((boulder) => (<option key={boulder}>{boulder}</option>))) :
+                        (Object.keys(ROPE_GRADES).map((grade) => (<option key={grade} value={grade}>{grade}</option>)))}
                 </select>
             </label>
 
@@ -70,7 +107,7 @@ export default function NewClimb() {
                 <p>What color are the holds?:</p>
                 <div className={'color-container'}>
                     <select name="color" required={true} onChange={e => setColor(e.target.value)}>
-                        {Object.keys(ROUTE_COLORS).map((color) => (<option value={color}>{color}</option>))}
+                        {Object.keys(ROUTE_COLORS).map((c) => (<option key={c} value={c}>{c}</option>))}
                     </select>
                     <div className={"cooler-circle"} style={{backgroundColor: ROUTE_COLORS[color]}}></div>
                 </div>
@@ -104,9 +141,24 @@ export default function NewClimb() {
                     <option value={"Ram's Head"}>Ram's Head</option>
                 </select>
             </label>
+
+            <label className={'picture-field'}>
+                <p>Photo of the climb (optional):</p>
+                <input
+                    type="file"
+                    name="picture"
+                    accept="image/*"
+                    onChange={onPictureChange}
+                />
+                {previewUrl && (
+                    <img className={'picture-preview'} src={previewUrl} alt={'Climb preview'}/>
+                )}
+            </label>
             </div>
 
-            <button className={'add-form-button'} type="submit">Submit</button>
+            <button className={'add-form-button'} type="submit" disabled={uploading}>
+                {uploading ? 'Uploading…' : 'Submit'}
+            </button>
         </form>
         <HomeRow/>
     </div>)

--- a/frontend/src/pages/styles/climbdetail.css
+++ b/frontend/src/pages/styles/climbdetail.css
@@ -1,0 +1,68 @@
+.climb-detail-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 16px;
+    gap: 16px;
+}
+
+.climb-detail-page .back-button {
+    align-self: flex-start;
+    border: 2px solid black;
+    border-radius: 12px;
+    background-color: #ECEDED;
+    padding: 4px 10px;
+    cursor: pointer;
+}
+
+.climb-detail-card {
+    background-color: #ECEDED;
+    border: 2px solid black;
+    border-radius: 16px;
+    width: min(480px, 90vw);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.climb-detail-image {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    display: block;
+}
+
+.climb-detail-placeholder {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #dcdcdc;
+    color: #555;
+    font-style: italic;
+}
+
+.climb-detail-body {
+    padding: 12px 16px 20px;
+}
+
+.climb-detail-heading {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.climb-detail-heading h1 {
+    font-size: 28px;
+    margin: 8px 0;
+}
+
+.climb-detail-body p {
+    margin: 4px 0;
+}
+
+.archived-tag {
+    color: #a94442;
+    font-weight: bold;
+}

--- a/frontend/src/pages/styles/climbelement.css
+++ b/frontend/src/pages/styles/climbelement.css
@@ -81,3 +81,27 @@ p {
     padding: 8px 8px 0 8px;
     height: fit-content;
 }
+
+.climb-thumbnail {
+    width: 72px;
+    height: 72px;
+    object-fit: cover;
+    border-radius: 12px;
+    border: 2px solid black;
+    align-self: center;
+    margin-left: 8px;
+    cursor: pointer;
+}
+
+.climb-details-link {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 4px;
+    font-size: 12px;
+    color: #3498db;
+    text-decoration: underline;
+    cursor: pointer;
+    text-align: left;
+    width: fit-content;
+}

--- a/frontend/src/pages/styles/newclimb.css
+++ b/frontend/src/pages/styles/newclimb.css
@@ -80,6 +80,24 @@
     align-items: center;
 }
 
+.picture-field input[type="file"] {
+    border: 2px dashed black;
+    border-radius: 16px;
+    background-color: #ECEDED;
+    padding: 8px;
+    width: 100%;
+}
+
+.picture-preview {
+    display: block;
+    margin-top: 8px;
+    max-width: 100%;
+    max-height: 240px;
+    border-radius: 12px;
+    border: 2px solid black;
+    object-fit: cover;
+}
+
 @media only screen and (min-width: 768px) {
     .add-form-fields {
         display: grid;

--- a/migrations/001_climb_images.sql
+++ b/migrations/001_climb_images.sql
@@ -1,0 +1,25 @@
+-- Adds image-upload support for climbs.
+--
+-- 1. Ensures the climbs.picture column exists (nullable text, stores the public URL
+--    returned by Supabase Storage).
+-- 2. Creates a public `climb-images` bucket that the frontend uploads into.
+-- 3. Adds permissive storage policies so authenticated setters can upload and anyone
+--    can read. Tighten these in production as needed.
+
+alter table public.climbs
+    add column if not exists picture text;
+
+insert into storage.buckets (id, name, public)
+values ('climb-images', 'climb-images', true)
+on conflict (id) do update set public = excluded.public;
+
+drop policy if exists "Climb images are publicly readable" on storage.objects;
+create policy "Climb images are publicly readable"
+    on storage.objects for select
+    using (bucket_id = 'climb-images');
+
+drop policy if exists "Authenticated users can upload climb images" on storage.objects;
+create policy "Authenticated users can upload climb images"
+    on storage.objects for insert
+    to authenticated
+    with check (bucket_id = 'climb-images');


### PR DESCRIPTION
## Summary

Adds photo upload for climbs so setters can attach a route picture that is then shown on the home feed and on a new climb detail page.

- **New climb form** — added an optional `<input type=\"file\">` in `newclimb.tsx`. The selected file is uploaded from the browser straight to the Supabase `climb-images` storage bucket via the existing `supabaseClient`; the returned public URL is sent to `POST /climbs/new` in a new `picture` field, which the backend persists into the existing `climbs.picture` column.
- **Backend** — `handleNewClimb` now passes through the `picture` URL, and a new `GET /climbs/:id` (typed with a `Params` generic) returns a single climb for the detail page. Follows the existing `packageResponse` pattern.
- **Climb card** — `ClimbElement` renders a thumbnail when `picture` is present and exposes a \"View details\" link that navigates to `/climb/:id` without interfering with the existing log-on-click selection behavior.
- **Detail page** — new `/climb/:id` route (added to `main.tsx`, guarded by `ProtectedRoute`) showing the full-size image and all climb metadata.
- **Migration** — `migrations/001_climb_images.sql` adds the `picture` column (idempotent), creates the public `climb-images` bucket, and installs two permissive storage policies (public read, authenticated insert). Has not been executed — run it against the Supabase project before deploying.
- **Bug fix** — `ProtectedRoute.tsx` was importing `Session` from `react-router-dom`, not `@supabase/supabase-js`, causing the `session` prop to type-check against the wrong type. Switched the import so the (pre-existing) 3 call sites and the new one type-check; this is a minimal fix needed for my added route.

## Follow-ups / manual steps

- **Run the migration** in Supabase (SQL editor or `supabase db push`) before merging to production.
- **Storage policies** shipped here are permissive (any authenticated user can upload, anyone can read). Tighten with owner-based RLS if setter identity becomes meaningful.
- **Pre-existing build errors** — both `backend && npm run build` and `frontend && npm run build` already failed on `main` with ~25 and ~22 TS errors respectively (wrong `Task` void typing in the backend, implicit-any/unused-import errors in `FilterClimbs`, `SearchBar`, `home.tsx`, etc.). This PR does not widen that set: all errors in files I touched (`ClimbElement`, `ProtectedRoute`, `main.tsx`, `newclimb.tsx`, new `climbdetail.tsx`) are fixed, and `npm run lint` is clean on every file I touched. Happy to clean up the pre-existing errors in a follow-up PR if desired.
- **Env** — no new env vars required; uploads use the existing `VITE` / anon Supabase credentials already wired through `supabaseClient`.

## Test plan

- [ ] Apply `migrations/001_climb_images.sql` in Supabase
- [ ] Start `backend` and `frontend`, log in, go to `/logclimb`
- [ ] Submit a climb with a photo — verify row is inserted with a non-null `picture` URL and the image is viewable at that URL
- [ ] On `/home`, the new climb shows a thumbnail; clicking the thumbnail or \"View details\" opens `/climb/:id` with the full image
- [ ] Submit a climb without a photo — still works, no thumbnail, detail page shows a \"No photo yet\" placeholder