### PR TITLE
feat: add global keyboard shortcuts and help overlay

### DIFF
--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,9 +1,11 @@
-import {useEffect, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import "./../pages/styles/SearchBar.css";
 import {BACKEND_URL, BOULDER_GRADES, ROPE_GRADES, ROUTE_COLORS} from "../lib/types.ts";
+import {FOCUS_SEARCH_EVENT} from "../lib/keyboardShortcuts.ts";
 
 export default function SearchBar({onSearch, onFilter, filtering}) {
     const [search, setSearch] = useState('');
+    const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         const searchAction = async () => {
@@ -18,6 +20,17 @@ export default function SearchBar({onSearch, onFilter, filtering}) {
         searchAction();
     }, [search]);
 
+    useEffect(() => {
+        const focusHandler = () => {
+            const input = inputRef.current;
+            if (!input) return;
+            input.focus();
+            input.select();
+        };
+        window.addEventListener(FOCUS_SEARCH_EVENT, focusHandler);
+        return () => window.removeEventListener(FOCUS_SEARCH_EVENT, focusHandler);
+    }, []);
+
 
     return (
         <div className={"search-bar"}>
@@ -29,6 +42,7 @@ export default function SearchBar({onSearch, onFilter, filtering}) {
             <form>
                 <br/>
                 <input
+                    ref={inputRef}
                     type="search"
                     name="search"
                     placeholder="Search by Route Name or Setter"

--- a/frontend/src/components/ShortcutsHelp.tsx
+++ b/frontend/src/components/ShortcutsHelp.tsx
@@ -1,0 +1,85 @@
+import {useEffect} from "react";
+import type {ShortcutDefinition} from "../lib/keyboardShortcuts.ts";
+import "../pages/styles/shortcutshelp.css";
+
+interface ShortcutsHelpProps {
+    open: boolean;
+    onClose: () => void;
+    shortcuts: ShortcutDefinition[];
+}
+
+function formatKeys(keys: string): string[] {
+    return keys.split("+").map((part) => part.trim());
+}
+
+export default function ShortcutsHelp({open, onClose, shortcuts}: ShortcutsHelpProps) {
+    useEffect(() => {
+        if (!open) return;
+        const handler = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+            }
+        };
+        window.addEventListener("keydown", handler);
+        return () => window.removeEventListener("keydown", handler);
+    }, [open, onClose]);
+
+    if (!open) return null;
+
+    const groups = shortcuts.reduce<Record<string, ShortcutDefinition[]>>((acc, shortcut) => {
+        (acc[shortcut.group] ||= []).push(shortcut);
+        return acc;
+    }, {});
+
+    return (
+        <div
+            className={"shortcuts-help-overlay"}
+            role={"dialog"}
+            aria-modal={"true"}
+            aria-label={"Keyboard shortcuts"}
+            onClick={onClose}
+        >
+            <div className={"shortcuts-help-panel"} onClick={(event) => event.stopPropagation()}>
+                <div className={"shortcuts-help-header"}>
+                    <h2>Keyboard Shortcuts</h2>
+                    <button
+                        type={"button"}
+                        className={"shortcuts-help-close"}
+                        onClick={onClose}
+                        aria-label={"Close shortcuts help"}
+                    >
+                        ×
+                    </button>
+                </div>
+                <div className={"shortcuts-help-body"}>
+                    {Object.entries(groups).map(([groupName, items]) => (
+                        <section key={groupName} className={"shortcuts-help-group"}>
+                            <h3>{groupName}</h3>
+                            <ul>
+                                {items.map((item) => (
+                                    <li key={item.keys}>
+                                        <span className={"shortcuts-help-keys"}>
+                                            {formatKeys(item.keys).map((token, index, arr) => (
+                                                <span key={index}>
+                                                    <kbd>{token}</kbd>
+                                                    {index < arr.length - 1 && (
+                                                        <span className={"shortcuts-help-sep"}>then</span>
+                                                    )}
+                                                </span>
+                                            ))}
+                                        </span>
+                                        <span className={"shortcuts-help-desc"}>{item.description}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+                <div className={"shortcuts-help-footer"}>
+                    Press <kbd>?</kbd> to toggle this help. Shortcuts are disabled while typing.
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/ShortcutsProvider.tsx
+++ b/frontend/src/components/ShortcutsProvider.tsx
@@ -1,0 +1,33 @@
+import {useCallback, useMemo, useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {dispatchFocusSearch, type ShortcutDefinition, useKeyboardShortcuts} from "../lib/keyboardShortcuts.ts";
+import ShortcutsHelp from "./ShortcutsHelp.tsx";
+
+interface ShortcutsProviderProps {
+    children: React.ReactNode;
+}
+
+export default function ShortcutsProvider({children}: ShortcutsProviderProps) {
+    const navigate = useNavigate();
+    const [helpOpen, setHelpOpen] = useState(false);
+
+    const closeHelp = useCallback(() => setHelpOpen(false), []);
+
+    const shortcuts = useMemo<ShortcutDefinition[]>(() => [
+        {keys: "g+h", description: "Go to Home", group: "Navigation", action: () => navigate("/home")},
+        {keys: "g+p", description: "Go to Profile", group: "Navigation", action: () => navigate("/profile")},
+        {keys: "g+n", description: "Go to New Climb", group: "Navigation", action: () => navigate("/logclimb")},
+        {keys: "n", description: "New climb", group: "Actions", action: () => navigate("/logclimb")},
+        {keys: "/", description: "Focus search", group: "Actions", action: () => dispatchFocusSearch()},
+        {keys: "?", description: "Toggle this help", group: "Help", action: () => setHelpOpen((open) => !open)},
+    ], [navigate]);
+
+    useKeyboardShortcuts(shortcuts);
+
+    return (
+        <>
+            {children}
+            <ShortcutsHelp open={helpOpen} onClose={closeHelp} shortcuts={shortcuts}/>
+        </>
+    );
+}

--- a/frontend/src/lib/keyboardShortcuts.ts
+++ b/frontend/src/lib/keyboardShortcuts.ts
@@ -1,0 +1,92 @@
+import {useEffect} from "react";
+
+export interface ShortcutDefinition {
+    keys: string;
+    description: string;
+    group: "Navigation" | "Actions" | "Help";
+    action: () => void;
+}
+
+const CHORD_TIMEOUT_MS = 1000;
+
+function isTypingTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    if (target.isContentEditable) return true;
+    const tag = target.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+export const FOCUS_SEARCH_EVENT = "clapp:focus-search";
+
+export function dispatchFocusSearch() {
+    window.dispatchEvent(new CustomEvent(FOCUS_SEARCH_EVENT));
+}
+
+export function useKeyboardShortcuts(shortcuts: ShortcutDefinition[]): void {
+    useEffect(() => {
+        const chordMap = new Map<string, Map<string, ShortcutDefinition>>();
+        const singleMap = new Map<string, ShortcutDefinition>();
+
+        for (const shortcut of shortcuts) {
+            const parts = shortcut.keys.split("+").map((p) => p.trim().toLowerCase());
+            if (parts.length === 1) {
+                singleMap.set(parts[0], shortcut);
+            } else if (parts.length === 2) {
+                const [first, second] = parts;
+                let inner = chordMap.get(first);
+                if (!inner) {
+                    inner = new Map();
+                    chordMap.set(first, inner);
+                }
+                inner.set(second, shortcut);
+            }
+        }
+
+        let pendingChord: string | null = null;
+        let chordTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const clearChord = () => {
+            pendingChord = null;
+            if (chordTimer) {
+                clearTimeout(chordTimer);
+                chordTimer = null;
+            }
+        };
+
+        const handler = (event: KeyboardEvent) => {
+            if (event.metaKey || event.ctrlKey || event.altKey) return;
+            if (isTypingTarget(event.target)) return;
+
+            const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+
+            if (pendingChord) {
+                const inner = chordMap.get(pendingChord);
+                const match = inner?.get(key);
+                clearChord();
+                if (match) {
+                    event.preventDefault();
+                    match.action();
+                }
+                return;
+            }
+
+            if (chordMap.has(key)) {
+                pendingChord = key;
+                chordTimer = setTimeout(clearChord, CHORD_TIMEOUT_MS);
+                return;
+            }
+
+            const direct = singleMap.get(key);
+            if (direct) {
+                event.preventDefault();
+                direct.action();
+            }
+        };
+
+        window.addEventListener("keydown", handler);
+        return () => {
+            window.removeEventListener("keydown", handler);
+            if (chordTimer) clearTimeout(chordTimer);
+        };
+    }, [shortcuts]);
+}

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -5,6 +5,7 @@ import type {Session} from "@supabase/supabase-js";
 import { supabaseClient} from "../util/supabaseClient.ts";
 import LoginPage from "./login.tsx";
 import ProtectedRoute from "./../components/ProtectedRoute";
+import ShortcutsProvider from "./../components/ShortcutsProvider";
 
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
@@ -30,33 +31,35 @@ function Root() {
     if (loading) return <div> Loading...</div>
 
     return (<BrowserRouter>
-        <Routes>
-            <Route index element={<LoginPage/>}/>
-            <Route
-                path="/home"
-                element={
-                    <ProtectedRoute session={session}>
-                        <Home/>
-                    </ProtectedRoute>
-                }
-            />
-            <Route
-                path="/logclimb"
-                element={
-                    <ProtectedRoute session={session}>
-                        <LogClimb/>
-                    </ProtectedRoute>
-                }
-            />
-            <Route
-                path="/profile"
-                element={
-                    <ProtectedRoute session={session}>
-                        <Profile/>
-                    </ProtectedRoute>
-                }
-            />
-        </Routes>
+        <ShortcutsProvider>
+            <Routes>
+                <Route index element={<LoginPage/>}/>
+                <Route
+                    path="/home"
+                    element={
+                        <ProtectedRoute session={session}>
+                            <Home/>
+                        </ProtectedRoute>
+                    }
+                />
+                <Route
+                    path="/logclimb"
+                    element={
+                        <ProtectedRoute session={session}>
+                            <LogClimb/>
+                        </ProtectedRoute>
+                    }
+                />
+                <Route
+                    path="/profile"
+                    element={
+                        <ProtectedRoute session={session}>
+                            <Profile/>
+                        </ProtectedRoute>
+                    }
+                />
+            </Routes>
+        </ShortcutsProvider>
     </BrowserRouter>);
 
 }

--- a/frontend/src/pages/styles/shortcutshelp.css
+++ b/frontend/src/pages/styles/shortcutshelp.css
@@ -1,0 +1,133 @@
+.shortcuts-help-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 16px;
+}
+
+.shortcuts-help-panel {
+    background: #fff;
+    color: #111;
+    border: 2px solid #000;
+    border-radius: 12px;
+    width: min(560px, 100%);
+    max-height: 85vh;
+    overflow-y: auto;
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+    display: flex;
+    flex-direction: column;
+}
+
+.shortcuts-help-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid #e5e5e5;
+}
+
+.shortcuts-help-header h2 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 700;
+}
+
+.shortcuts-help-close {
+    background: none;
+    border: none;
+    font-size: 28px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 6px;
+    color: #333;
+}
+
+.shortcuts-help-close:hover {
+    color: #000;
+}
+
+.shortcuts-help-body {
+    padding: 12px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.shortcuts-help-group h3 {
+    margin: 0 0 8px 0;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #555;
+    font-weight: 700;
+}
+
+.shortcuts-help-group ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.shortcuts-help-group li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 6px 0;
+}
+
+.shortcuts-help-keys {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.shortcuts-help-keys kbd {
+    background: #f4f4f5;
+    border: 1px solid #d4d4d8;
+    border-bottom-width: 2px;
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 13px;
+    padding: 2px 8px;
+    min-width: 22px;
+    text-align: center;
+    display: inline-block;
+    color: #111;
+}
+
+.shortcuts-help-sep {
+    font-size: 12px;
+    color: #777;
+    margin: 0 2px;
+}
+
+.shortcuts-help-desc {
+    color: #333;
+    font-size: 14px;
+    text-align: right;
+}
+
+.shortcuts-help-footer {
+    border-top: 1px solid #e5e5e5;
+    padding: 12px 20px;
+    font-size: 12px;
+    color: #555;
+}
+
+.shortcuts-help-footer kbd {
+    background: #f4f4f5;
+    border: 1px solid #d4d4d8;
+    border-bottom-width: 2px;
+    border-radius: 4px;
+    font-size: 11px;
+    padding: 1px 6px;
+}


### PR DESCRIPTION
## Summary

Adds a global keyboard shortcut system for power users and a discoverable help overlay so the bindings are easy to find.

### Bindings

**Navigation (chord — press the first key, then the second within 1s):**
- `g` then `h` — Home
- `g` then `p` — Profile
- `g` then `n` — New Climb

**Actions:**
- `n` — New Climb
- `/` — focus the search bar on Home

**Help:**
- `?` — toggle the shortcuts help overlay
- `Escape` — close the overlay

Shortcuts are suppressed while the user is typing in `<input>`, `<textarea>`, `<select>`, or any contenteditable element, so they never interfere with form entry. Modifier-key combinations (Ctrl/Cmd/Alt) are also ignored to avoid colliding with browser shortcuts.

## Implementation

- `frontend/src/lib/keyboardShortcuts.ts` — `useKeyboardShortcuts` hook supporting both single-key and two-key chord bindings, plus a `FOCUS_SEARCH_EVENT` custom event for `/`.
- `frontend/src/components/ShortcutsProvider.tsx` — declares the binding table and renders the help overlay; mounted inside `BrowserRouter` so it has `useNavigate`.
- `frontend/src/components/ShortcutsHelp.tsx` + `pages/styles/shortcutshelp.css` — modal overlay grouped by Navigation / Actions / Help with `<kbd>` chips.
- `frontend/src/components/SearchBar.tsx` — listens for `FOCUS_SEARCH_EVENT` and focuses + selects its input.
- `frontend/src/pages/main.tsx` — wraps `<Routes>` in `<ShortcutsProvider>`.

## Assumptions / notes

- The repo had no test runner wired up, so this PR adds no tests; the shortcut behavior was verified by reading the keyboard handler logic. Manual smoke-testing instructions are in the test plan below.
- `cd frontend && npm run build` and `cd frontend && npm run lint` both have **pre-existing** TypeScript and lint errors on `main` (unrelated `any` parameters, unused imports, Session typing issues). I confirmed by diffing the error sets that this PR introduces **zero new** TS or lint errors — only line-number shifts in pre-existing diagnostics for `SearchBar.tsx` and `main.tsx`. Backend was not modified.
- No DB migrations, env vars, or external API keys needed.

## Test plan

- [ ] On any authenticated page, press `?` — help overlay appears listing all shortcuts grouped by section.
- [ ] Press `Escape` or click the backdrop — overlay closes.
- [ ] Press `g` then `h` within ~1 second — navigates to `/home`.
- [ ] Press `g` then `p` — navigates to `/profile`.
- [ ] Press `n` (not in an input) — navigates to `/logclimb`.
- [ ] On `/home`, press `/` — focus jumps to the search input and any existing text is selected.
- [ ] Type a query inside the search input — pressing `g`, `n`, `/`, `?` does **not** trigger any shortcut while focused.
- [ ] `Ctrl+R` / `Cmd+R` still reloads the page (modifier combos are ignored by the handler).