### PR TITLE
feat: 1-5 star climb rating system

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -11,7 +11,7 @@ import {
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
+    BOULDER_GRADES, type Log, type Rating
 } from "../../frontend/src/lib/types.ts";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
@@ -67,6 +67,30 @@ export function setupRoutes(server: FastifyInstance) {
         Reply: BaseReply<void>;
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.post<{
+        Body: Rating;
+        Reply: BaseReply<void>;
+    }>("/climbs/rate", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleRate(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.get<{
+        Params: { climbId: string };
+        Reply: BaseReply<void>;
+    }>("/climbs/rating/:climbId", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleRatingSummary(req.params));
+        res.status(code).send(reply);
+    });
+
+    server.get<{
+        Params: { climbId: string; userId: string };
+        Reply: BaseReply<void>;
+    }>("/climbs/rating/:climbId/:userId", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleUserRating(req.params));
         res.status(code).send(reply);
     });
 
@@ -222,6 +246,62 @@ export function setupRoutes(server: FastifyInstance) {
             return {success: false, error: error, code: 500};
         }
         return {success: true, data: data};
+    }
+
+
+    async function handleRate(req: Rating): Promise<Task> {
+        const {user, climb, rating} = req;
+        if (!user || !climb || typeof rating !== "number" || rating < 1 || rating > 5 || !Number.isInteger(rating)) {
+            return {success: false, error: new Error("rating must be an integer between 1 and 5"), code: 400};
+        }
+        const {data, error} = await server.supabase
+            .from("climb_ratings")
+            .upsert(
+                {climber: user, climb: climb, rating: rating, updated_at: new Date().toISOString()},
+                {onConflict: "climb,climber"}
+            )
+            .select();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data as any};
+    }
+
+    async function handleRatingSummary(params: { climbId?: string }): Promise<Task> {
+        const {climbId} = params;
+        if (!climbId) {
+            return {success: false, error: new Error("climbId required"), code: 400};
+        }
+        const {data, error} = await server.supabase
+            .from("climb_ratings")
+            .select("rating")
+            .eq("climb", climbId);
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        const ratings = (data ?? []) as { rating: number }[];
+        const count = ratings.length;
+        const average = count === 0
+            ? 0
+            : Math.round((ratings.reduce((sum, r) => sum + r.rating, 0) / count) * 100) / 100;
+        return {success: true, data: {average, count} as any};
+    }
+
+    async function handleUserRating(params: { climbId?: string; userId?: string }): Promise<Task> {
+        const {climbId, userId} = params;
+        if (!climbId || !userId) {
+            return {success: false, error: new Error("climbId and userId required"), code: 400};
+        }
+        const {data, error} = await server.supabase
+            .from("climb_ratings")
+            .select("rating")
+            .eq("climb", climbId)
+            .eq("climber", userId)
+            .maybeSingle();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: (data ?? {rating: 0}) as any};
     }
 
 

--- a/frontend/src/components/ClimbElement.tsx
+++ b/frontend/src/components/ClimbElement.tsx
@@ -1,15 +1,18 @@
-import {type Climb, ROUTE_COLORS} from "../lib/types.ts";
+import {type Climb, ROUTE_COLORS, BACKEND_URL} from "../lib/types.ts";
 import '../pages/styles/climbelement.css'
-import {useState} from "react";
+import {useEffect, useState} from "react";
+import RatingStars from "./RatingStars.tsx";
+import {toast} from "react-toastify";
 
 interface ClimbElementProps {
     jsonClimb: Climb;
     climbId: number;
     onLog: (climb: Climb) => void;
     isSelected: boolean;
+    userId?: string;
 }
 
-export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: ClimbElementProps) {
+export default function ClimbElement({jsonClimb, climbId, onLog, isSelected, userId}: ClimbElementProps) {
     const climbAdapter = (data) => {
         return {
             name: data.name,
@@ -23,6 +26,50 @@ export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: Cl
         }
     };
     const {name, difficulty, type, color, setter, dateSet, gym} = climbAdapter(jsonClimb);
+    const [average, setAverage] = useState<number>(0);
+    const [count, setCount] = useState<number>(0);
+    const [userRating, setUserRating] = useState<number>(0);
+
+    useEffect(() => {
+        let cancelled = false;
+        const fetchSummary = async () => {
+            try {
+                const res = await fetch(`${BACKEND_URL}/climbs/rating/${climbId}`);
+                const data = await res.json();
+                if (!cancelled && data.success) {
+                    setAverage(data.data.average ?? 0);
+                    setCount(data.data.count ?? 0);
+                }
+            } catch {
+                // network error — leave defaults
+            }
+        };
+        fetchSummary();
+        return () => {
+            cancelled = true;
+        };
+    }, [climbId]);
+
+    useEffect(() => {
+        if (!userId) return;
+        let cancelled = false;
+        const fetchUserRating = async () => {
+            try {
+                const res = await fetch(`${BACKEND_URL}/climbs/rating/${climbId}/${userId}`);
+                const data = await res.json();
+                if (!cancelled && data.success) {
+                    setUserRating(data.data.rating ?? 0);
+                }
+            } catch {
+                // ignore
+            }
+        };
+        fetchUserRating();
+        return () => {
+            cancelled = true;
+        };
+    }, [climbId, userId]);
+
     const logClimb = () => {
         onLog(climbId);
     }
@@ -31,6 +78,38 @@ export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: Cl
         const date = new Date(year, month - 1, day);
         const shortYear = date.getFullYear().toString().slice(-2);
         return `${month}/${day}/${shortYear}`;
+    };
+
+    const handleRate = async (rating: number) => {
+        if (!userId) {
+            toast.error("Sign in to rate climbs", {autoClose: 2500});
+            return;
+        }
+        const previous = userRating;
+        setUserRating(rating);
+        try {
+            const res = await fetch(`${BACKEND_URL}/climbs/rate`, {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({user: userId, climb: climbId, rating}),
+            });
+            const data = await res.json();
+            if (!data.success) {
+                setUserRating(previous);
+                toast.error("Failed to save rating", {autoClose: 2500});
+                return;
+            }
+            const summaryRes = await fetch(`${BACKEND_URL}/climbs/rating/${climbId}`);
+            const summary = await summaryRes.json();
+            if (summary.success) {
+                setAverage(summary.data.average ?? 0);
+                setCount(summary.data.count ?? 0);
+            }
+            toast(previous === 0 ? "Rating submitted" : "Rating updated", {autoClose: 2000});
+        } catch {
+            setUserRating(previous);
+            toast.error("Failed to save rating", {autoClose: 2500});
+        }
     };
 
 
@@ -47,6 +126,15 @@ export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: Cl
                     <path d="M8 8a2 2 0 1 1 0-4 2 2 0 0 1 0 4m0 1a3 3 0 1 0 0-6 3 3 0 0 0 0 6"/>
                 </svg>
                 <p>{gym} • {type}</p>
+            </div>
+            <div className={'climb-rating'}>
+                <RatingStars
+                    value={userId ? userRating || average : average}
+                    count={count}
+                    interactive={!!userId}
+                    onRate={handleRate}
+                    size={16}
+                />
             </div>
 
         </div>

--- a/frontend/src/components/RatingStars.tsx
+++ b/frontend/src/components/RatingStars.tsx
@@ -1,0 +1,50 @@
+import {useState} from "react";
+import "../pages/styles/ratingstars.css";
+
+interface RatingStarsProps {
+    value: number;
+    count?: number;
+    interactive?: boolean;
+    size?: number;
+    onRate?: (rating: number) => void;
+}
+
+export default function RatingStars({value, count, interactive = false, size = 18, onRate}: RatingStarsProps) {
+    const [hover, setHover] = useState<number | null>(null);
+    const display = hover ?? value;
+
+    const handleClick = (e: React.MouseEvent, star: number) => {
+        if (!interactive || !onRate) return;
+        e.stopPropagation();
+        onRate(star);
+    };
+
+    return (
+        <div
+            className={`rating-stars ${interactive ? "interactive" : ""}`}
+            onMouseLeave={() => setHover(null)}
+            onClick={(e) => interactive && e.stopPropagation()}
+        >
+            {[1, 2, 3, 4, 5].map((star) => {
+                const filled = display >= star;
+                const half = !filled && display >= star - 0.5;
+                return (
+                    <span
+                        key={star}
+                        className={`star ${filled ? "filled" : half ? "half" : "empty"}`}
+                        style={{fontSize: `${size}px`, lineHeight: 1}}
+                        onMouseEnter={() => interactive && setHover(star)}
+                        onClick={(e) => handleClick(e, star)}
+                        role={interactive ? "button" : undefined}
+                        aria-label={interactive ? `Rate ${star} stars` : undefined}
+                    >
+                        {filled ? "★" : half ? "★" : "☆"}
+                    </span>
+                );
+            })}
+            {count !== undefined && count > 0 && (
+                <span className="rating-count">({count})</span>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,17 @@ export interface Log {
     climb: number;
 }
 
+export interface Rating {
+    user: string;
+    climb: number;
+    rating: number;
+}
+
+export interface RatingSummary {
+    average: number;
+    count: number;
+}
+
 export const BACKEND_URL: string = 'http://localhost:8000';
 export const FRONTEND_URL: string = 'http://localhost:5173';
 

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -155,7 +155,7 @@ export default function Home() {
             {climbs.length > 0 ? (climbs.map((climb) => (
 
                     <ClimbElement key={climb.id} climbId={climb.id} jsonClimb={climb} onLog={onLog}
-                                  isSelected={log === climb.id}/>
+                                  isSelected={log === climb.id} userId={user?.id}/>
                 ))
             ) : (loading ? (<p>Loading...</p>) : (<p>No climbs found</p>))}
 

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -62,8 +62,8 @@ export default function Profile() {
 
                     <div className={"climbs-profile"}>
                         {climbs.length > 0 ? (climbs.map((climb) => (
-                                <ClimbElement key={climb.id} climbId={climb.id} jsonClimb={climb.climbs} onLog={() => {
-                                }} isSelected={false}/>
+                                <ClimbElement key={climb.id} climbId={climb.climbs?.id ?? climb.id} jsonClimb={climb.climbs} onLog={() => {
+                                }} isSelected={false} userId={user?.id}/>
                             ))
                         ) : (loading ? (<p>Loading...</p>) : (<p>No climbs found</p>))}
                     </div>

--- a/frontend/src/pages/styles/ratingstars.css
+++ b/frontend/src/pages/styles/ratingstars.css
@@ -1,0 +1,44 @@
+.rating-stars {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+    color: #c7c7c7;
+}
+
+.rating-stars .star {
+    cursor: default;
+    transition: color 0.1s ease;
+}
+
+.rating-stars .star.filled {
+    color: #f5b301;
+}
+
+.rating-stars .star.half {
+    color: #f5d27a;
+}
+
+.rating-stars .star.empty {
+    color: #c7c7c7;
+}
+
+.rating-stars.interactive .star {
+    cursor: pointer;
+}
+
+.rating-stars.interactive .star:hover,
+.rating-stars.interactive .star.filled {
+    color: #f5b301;
+}
+
+.rating-count {
+    margin-left: 4px;
+    font-size: 12px;
+    color: #555;
+}
+
+.climb-rating {
+    display: flex;
+    align-items: center;
+    margin: 4px;
+}

--- a/migrations/20260423_create_climb_ratings.sql
+++ b/migrations/20260423_create_climb_ratings.sql
@@ -1,0 +1,43 @@
+create table if not exists public.climb_ratings (
+    id bigserial primary key,
+    climb bigint not null references public.climbs (id) on delete cascade,
+    climber uuid not null references auth.users (id) on delete cascade,
+    rating smallint not null check (rating between 1 and 5),
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (climb, climber)
+);
+
+create index if not exists climb_ratings_climb_idx on public.climb_ratings (climb);
+create index if not exists climb_ratings_climber_idx on public.climb_ratings (climber);
+
+create or replace view public.climb_rating_summary as
+select
+    climb,
+    round(avg(rating)::numeric, 2) as average_rating,
+    count(*)::int as rating_count
+from public.climb_ratings
+group by climb;
+
+alter table public.climb_ratings enable row level security;
+
+drop policy if exists "ratings are readable by everyone" on public.climb_ratings;
+create policy "ratings are readable by everyone"
+    on public.climb_ratings for select
+    using (true);
+
+drop policy if exists "users can insert their own rating" on public.climb_ratings;
+create policy "users can insert their own rating"
+    on public.climb_ratings for insert
+    with check (auth.uid() = climber);
+
+drop policy if exists "users can update their own rating" on public.climb_ratings;
+create policy "users can update their own rating"
+    on public.climb_ratings for update
+    using (auth.uid() = climber)
+    with check (auth.uid() = climber);
+
+drop policy if exists "users can delete their own rating" on public.climb_ratings;
+create policy "users can delete their own rating"
+    on public.climb_ratings for delete
+    using (auth.uid() = climber);


### PR DESCRIPTION
## Summary

Adds a 1-5 star rating system for climbs. Each authenticated user can rate a climb once (rating is upserted on subsequent submissions), and every `ClimbElement` now shows the average rating with the per-rating count next to the existing climb info.

## What changed

**Database (`migrations/20260423_create_climb_ratings.sql`)**
- New `climb_ratings` table: `(id, climb → climbs(id), climber → auth.users(id), rating smallint 1..5, created_at, updated_at)` with `unique (climb, climber)` so the upsert path is deterministic.
- Indexes on `climb` and `climber`.
- A `climb_rating_summary` view (avg + count) — kept in case other clients want to read directly.
- RLS enabled with policies: ratings readable by all; insert/update/delete restricted to `auth.uid() = climber`.

**Backend (`backend/src/routes.ts`)**
- `POST /climbs/rate` — upserts a rating for `(user, climb)` (server-side validation rejects anything outside integer 1..5).
- `GET /climbs/rating/:climbId` — returns `{average, count}` (computed in the handler so it doesn't depend on the view).
- `GET /climbs/rating/:climbId/:userId` — returns the current user's rating, or `{rating: 0}` if absent.
- All three follow the existing `packageResponse(...)` pattern.

**Frontend**
- New `RatingStars` component (`frontend/src/components/RatingStars.tsx`) — display + interactive modes, supports half-stars for non-integer averages.
- `ClimbElement` now fetches the rating summary + the user's own rating on mount and renders `<RatingStars>` in the left column. When a `userId` is passed, stars are interactive; clicking a star upserts via `POST /climbs/rate`, optimistically updates local state, and rolls back on error. A toast confirms submit/update.
- `home.tsx` and `profile.tsx` thread `userId` (the Supabase user id) into `ClimbElement`.
- Added `Rating` and `RatingSummary` types in `frontend/src/lib/types.ts`.
- `ratingstars.css` for star colors / sizing.

## Assumptions

- Climbs are stored in the `climbs` table with a numeric `id` PK (matches the existing `req.body.climb: number` log signature).
- Users authenticate via Supabase auth (`auth.users.id` is a uuid) — already true based on `supabaseClient` usage.
- A user's most recent submission supersedes their previous one (upsert), rather than appending a new row each time.
- Average is rounded to 2 decimal places server-side; the UI shows half-star granularity.

## Follow-ups (must run before this is usable in prod)

- **Run the SQL migration** in `migrations/20260423_create_climb_ratings.sql` against the Supabase project. It is not auto-applied.
- No new env vars required.
- Existing TypeScript / lint errors in the repo are unrelated and untouched; this PR introduces zero new TS errors and zero new lint errors (in fact lint count drops by one because the `useState` import in `ClimbElement` is now actually used).

## Test plan

- [ ] Apply the migration; confirm `climb_ratings` and `climb_rating_summary` exist with RLS enabled.
- [ ] As a signed-in user, click a star on a climb → confirm POST `/climbs/rate` returns success and the average + count update.
- [ ] Click a different star → confirm the upsert path replaces the prior rating (count unchanged, average shifts).
- [ ] Reload the page → confirm the user's stored rating is reflected, and the average/count match across Home and Profile.
- [ ] As a signed-out user, confirm stars render in display-only mode (non-interactive).