### PR TITLE
feat: user stats page with totals, grade/type distribution, and send streak

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -11,7 +11,8 @@ import {
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
+    BOULDER_GRADES, type Log,
+    type UserStats
 } from "../../frontend/src/lib/types.ts";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
@@ -67,6 +68,14 @@ export function setupRoutes(server: FastifyInstance) {
         Reply: BaseReply<void>;
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.get<{
+        Reply: BaseReply<UserStats>;
+        Params: { uuid: string };
+    }>("/stats/:uuid", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleUserStats(req.params));
         res.status(code).send(reply);
     });
 
@@ -222,6 +231,69 @@ export function setupRoutes(server: FastifyInstance) {
             return {success: false, error: error, code: 500};
         }
         return {success: true, data: data};
+    }
+
+    async function handleUserStats(params: { uuid?: string }): Promise<Process<UserStats>> {
+        const {uuid} = params;
+        const {data, error} = await server.supabase.from("completed_climbs").select(`
+            *,
+            climbs:climb(*)`).eq("climber", uuid);
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        const records = (data ?? []) as Array<{
+            created_at?: string;
+            logged_at?: string;
+            date_logged?: string;
+            climbs?: { difficulty?: string; type?: string } | null;
+        }>;
+
+        const byGrade: Record<string, number> = {};
+        const byType: Record<string, number> = {};
+        for (const r of records) {
+            const climb = r.climbs;
+            if (!climb) continue;
+            const grade = climb.difficulty ?? "Unknown";
+            byGrade[grade] = (byGrade[grade] ?? 0) + 1;
+            const rawType = climb.type ?? "Unknown";
+            const bucket = rawType === "Boulder" ? "Boulder" : rawType === "Top Rope" ? "Top Rope" : rawType;
+            byType[bucket] = (byType[bucket] ?? 0) + 1;
+        }
+
+        const currentStreak = computeStreak(records.map(r => r.created_at ?? r.logged_at ?? r.date_logged).filter((d): d is string => !!d));
+
+        return {
+            success: true,
+            data: {
+                total: records.length,
+                byGrade,
+                byType,
+                currentStreak,
+            },
+        };
+    }
+
+    function computeStreak(isoDates: string[]): number {
+        if (isoDates.length === 0) return 0;
+        const MS_PER_DAY = 86_400_000;
+        const toDayUtc = (iso: string) => {
+            const d = new Date(iso);
+            return Math.floor(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) / MS_PER_DAY);
+        };
+        const days = new Set(isoDates.map(toDayUtc));
+        const today = Math.floor(Date.UTC(
+            new Date().getUTCFullYear(),
+            new Date().getUTCMonth(),
+            new Date().getUTCDate(),
+        ) / MS_PER_DAY);
+        let cursor = days.has(today) ? today : today - 1;
+        if (!days.has(cursor)) return 0;
+        let streak = 0;
+        while (days.has(cursor)) {
+            streak += 1;
+            cursor -= 1;
+        }
+        return streak;
     }
 
 

--- a/frontend/src/components/HomeRow.tsx
+++ b/frontend/src/components/HomeRow.tsx
@@ -22,6 +22,14 @@ export default function HomeRow() {
                 </svg>
                 <p>Add Climb</p>
             </div>
+            <div className={'stats-button'} onClick={() => navigate("/stats")}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
+                     className="bi bi-bar-chart" viewBox="0 0 16 16">
+                    <path
+                        d="M4 11H2v3h2zm5-4H7v7h2zm5-5v12h-2V2zm-2-1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM6 7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1zm-5 4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1z"/>
+                </svg>
+                <p>Stats</p>
+            </div>
             <div className={'profile-button'} onClick={() => navigate("/profile")}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
                      className="bi bi-person" viewBox="0 0 16 16" >

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,13 @@ export interface Log {
     climb: number;
 }
 
+export interface UserStats {
+    total: number;
+    byGrade: Record<string, number>;
+    byType: Record<string, number>;
+    currentStreak: number;
+}
+
 export const BACKEND_URL: string = 'http://localhost:8000';
 export const FRONTEND_URL: string = 'http://localhost:5173';
 

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import Stats from "./stats.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -53,6 +54,14 @@ function Root() {
                 element={
                     <ProtectedRoute session={session}>
                         <Profile/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/stats"
+                element={
+                    <ProtectedRoute session={session}>
+                        <Stats/>
                     </ProtectedRoute>
                 }
             />

--- a/frontend/src/pages/stats.tsx
+++ b/frontend/src/pages/stats.tsx
@@ -1,0 +1,137 @@
+import {useEffect, useState} from "react";
+import type {User} from "@supabase/supabase-js";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import HomeRow from "../components/HomeRow.tsx";
+import {BACKEND_URL, BOULDER_GRADES, ROPE_GRADES, type UserStats} from "../lib/types.ts";
+import "./styles/stats.css";
+
+function sortGrades(grades: string[]): string[] {
+    const rank = (g: string): number => {
+        if (g in BOULDER_GRADES) return BOULDER_GRADES[g];
+        if (g in ROPE_GRADES) return ROPE_GRADES[g];
+        return Number.POSITIVE_INFINITY;
+    };
+    return [...grades].sort((a, b) => rank(a) - rank(b));
+}
+
+interface BarRowProps {
+    label: string;
+    count: number;
+    max: number;
+}
+
+function BarRow({label, count, max}: BarRowProps) {
+    const pct = max === 0 ? 0 : Math.round((count / max) * 100);
+    return (
+        <div className={"stat-bar-row"}>
+            <span className={"stat-bar-label"}>{label}</span>
+            <div className={"stat-bar-track"}>
+                <div className={"stat-bar-fill"} style={{width: `${pct}%`}}/>
+            </div>
+            <span className={"stat-bar-count"}>{count}</span>
+        </div>
+    );
+}
+
+export default function Stats() {
+    const [user, setUser] = useState<User>();
+    const [stats, setStats] = useState<UserStats | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchUser = async () => {
+            const {data: {user}} = await supabaseClient.auth.getUser();
+            setUser(user ?? undefined);
+        };
+        fetchUser();
+    }, []);
+
+    useEffect(() => {
+        if (!user?.id) return;
+        const fetchStats = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await fetch(`${BACKEND_URL}/stats/${user.id}`);
+                const data = await response.json();
+                if (data.success) {
+                    setStats(data.data);
+                } else {
+                    setError(data.error ?? data.message ?? "Failed to load stats");
+                }
+            } catch (e) {
+                setError(e instanceof Error ? e.message : "Failed to load stats");
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchStats();
+    }, [user]);
+
+    const userName = user?.user_metadata?.name;
+    const grades = stats ? sortGrades(Object.keys(stats.byGrade)) : [];
+    const gradeMax = stats ? Math.max(1, ...Object.values(stats.byGrade)) : 1;
+    const typeEntries = stats ? Object.entries(stats.byType) : [];
+    const typeMax = stats ? Math.max(1, ...Object.values(stats.byType)) : 1;
+
+    return (
+        <>
+            <div className={"stats-page"}>
+                <div className={"stats-heading"}>
+                    <h1>Climbing Stats</h1>
+                    {userName && <p className={"stats-subtitle"}>{userName}</p>}
+                </div>
+
+                {loading && <p>Loading...</p>}
+                {error && <p className={"stats-error"}>{error}</p>}
+
+                {stats && !loading && (
+                    <div className={"stats-grid"}>
+                        <div className={"stats-card stats-card-total"}>
+                            <h2>Total Climbs</h2>
+                            <p className={"stats-big-number"}>{stats.total}</p>
+                        </div>
+
+                        <div className={"stats-card stats-card-streak"}>
+                            <h2>Current Send Streak</h2>
+                            <p className={"stats-big-number"}>{stats.currentStreak}</p>
+                            <p className={"stats-unit"}>{stats.currentStreak === 1 ? "day" : "days"}</p>
+                        </div>
+
+                        <div className={"stats-card stats-card-wide"}>
+                            <h2>By Grade</h2>
+                            {grades.length === 0 ? (
+                                <p>No climbs logged yet.</p>
+                            ) : (
+                                <div className={"stat-bars"}>
+                                    {grades.map(g => (
+                                        <BarRow key={g} label={g} count={stats.byGrade[g]} max={gradeMax}/>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+
+                        <div className={"stats-card stats-card-wide"}>
+                            <h2>By Type</h2>
+                            {typeEntries.length === 0 ? (
+                                <p>No climbs logged yet.</p>
+                            ) : (
+                                <div className={"stat-bars"}>
+                                    {typeEntries.map(([t, c]) => (
+                                        <BarRow key={t} label={t} count={c} max={typeMax}/>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {stats && !loading && stats.total === 0 && (
+                    <p className={"stats-empty"}>Log a climb from the home page to start building your stats.</p>
+                )}
+            </div>
+            <HomeRow/>
+        </>
+    );
+}

--- a/frontend/src/pages/styles/homerow.css
+++ b/frontend/src/pages/styles/homerow.css
@@ -26,6 +26,13 @@
     align-items: center;
 }
 
+.stats-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 10vw;
+}
+
 .profile-button {
     display: flex;
     flex-direction: row;
@@ -62,6 +69,10 @@
     }
 
     .add-button {
+        margin-left: 20px;
+    }
+
+    .stats-button {
         margin-left: 20px;
     }
 

--- a/frontend/src/pages/styles/stats.css
+++ b/frontend/src/pages/styles/stats.css
@@ -1,0 +1,115 @@
+.stats-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 16px;
+    padding-bottom: 96px;
+    gap: 16px;
+}
+
+.stats-heading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border: 3px solid black;
+    background-color: #EDCDB7;
+    padding: 8px 16px;
+}
+
+.stats-heading h1 {
+    margin: 0;
+}
+
+.stats-subtitle {
+    margin: 4px 0 0 0;
+    font-style: italic;
+}
+
+.stats-error {
+    color: #a00;
+}
+
+.stats-empty {
+    margin-top: 16px;
+    font-style: italic;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 16px;
+    width: 100%;
+    max-width: 800px;
+}
+
+.stats-card {
+    border: 3px solid black;
+    background-color: #EDCDB7;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.stats-card h2 {
+    margin: 0 0 8px 0;
+    font-size: 1.1rem;
+}
+
+.stats-big-number {
+    font-size: 2.5rem;
+    font-weight: bold;
+    margin: 0;
+    line-height: 1;
+}
+
+.stats-unit {
+    margin: 4px 0 0 0;
+    font-size: 0.9rem;
+}
+
+.stat-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 100%;
+}
+
+.stat-bar-row {
+    display: grid;
+    grid-template-columns: 60px 1fr 32px;
+    align-items: center;
+    gap: 8px;
+}
+
+.stat-bar-label {
+    font-weight: bold;
+    font-size: 0.9rem;
+}
+
+.stat-bar-track {
+    background-color: rgba(0, 0, 0, 0.1);
+    border: 1px solid black;
+    height: 14px;
+    position: relative;
+}
+
+.stat-bar-fill {
+    background-color: #c96a3a;
+    height: 100%;
+}
+
+.stat-bar-count {
+    font-size: 0.9rem;
+    text-align: right;
+}
+
+@media only screen and (min-width: 768px) {
+    .stats-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .stats-card-wide {
+        grid-column: span 2;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a per-user climbing-stats page backed by a new aggregation endpoint on the Fastify backend.

**Backend** — new `GET /stats/:uuid` route on Fastify that queries `completed_climbs` joined with `climbs` for the given user and returns:
- `total` — total logged climbs
- `byGrade` — histogram of difficulty grade → count
- `byType` — histogram of climb type (Boulder / Top Rope / other) → count
- `currentStreak` — number of consecutive calendar days (UTC) with at least one completed climb, ending either today or yesterday so a send today is not required to maintain yesterday's streak

Grade/type values come straight from the existing `climbs` row, so no migration is required. The route follows the existing `packageResponse` wrapper pattern used by the other handlers. A `UserStats` type was added to `frontend/src/lib/types.ts` and shared via the existing cross-package type import.

**Frontend** — new `/stats` React Router route and `pages/stats.tsx` page (protected with the existing `ProtectedRoute`), styled with a dedicated `stats.css` that matches the existing tan/black card look used on profile/home. Distributions are rendered as labeled horizontal bars; grades are sorted using the `BOULDER_GRADES` / `ROPE_GRADES` rank maps so V0 < V1 < … and 5.5 < 5.6 < …. A new chart-icon nav button was added to `HomeRow` so the page is reachable from every authenticated screen.

## Assumptions

- The timestamp column on `completed_climbs` is one of `created_at`, `logged_at`, or `date_logged` — the handler reads whichever is present (Supabase's default is `created_at` on tables created via the dashboard, so the streak should work out of the box). If none of those exist on the table, the streak will always report `0` and the rest of the stats still render correctly — rename the column or add one of those fields to turn streak on.
- Streak is computed in UTC. A user climbing around midnight local time could see their streak tick a day earlier/later than they expect; good enough for v1.
- Grades that are present in `completed_climbs` but missing from the rank maps fall to the end of the sorted list (rank = +∞).

## Test plan

- [ ] `npm --prefix backend run build` — note: baseline `main` already has 25 unrelated TS errors; this PR adds no new ones.
- [ ] `npm --prefix frontend run build` — baseline has 23 TS errors; this PR adds 1 additional instance of the pre-existing `ProtectedRoute session` type mismatch (same pattern as the other three protected routes). Fixing it properly requires fixing `ProtectedRoute.tsx`'s prop typing, which is out of scope for this change.
- [ ] Log a few climbs as a test user, visit `/stats`, confirm totals, bars, and streak.
- [ ] Confirm the new chart-icon button in `HomeRow` navigates to `/stats`.

## Follow-ups

- No new env vars; no migrations required.
- Fixing `ProtectedRoute`'s prop type (it imports `Session` from `react-router-dom` but is handed a `@supabase/supabase-js` `Session | null`) would clean up four lingering TS errors on `main` including the one this PR adds.