### PR TITLE
feat: in-app notification center (bell icon + Supabase notifications table)

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -11,7 +11,9 @@ import {
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
+    BOULDER_GRADES,
+    type Log,
+    type NewNotification
 } from "../../frontend/src/lib/types.ts";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
@@ -67,6 +69,31 @@ export function setupRoutes(server: FastifyInstance) {
         Reply: BaseReply<void>;
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.get("/notifications/:uuid", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleGetNotifications(req.params as { uuid?: string }));
+        res.status(code).send(reply);
+    });
+
+    server.get("/notifications/:uuid/unread-count", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleUnreadCount(req.params as { uuid?: string }));
+        res.status(code).send(reply);
+    });
+
+    server.post("/notifications", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleCreateNotification(req.body as NewNotification));
+        res.status(code).send(reply);
+    });
+
+    server.patch("/notifications/:id/read", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleMarkRead(req.params as { id?: string }));
+        res.status(code).send(reply);
+    });
+
+    server.patch("/notifications/:uuid/read-all", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleMarkAllRead(req.params as { uuid?: string }));
         res.status(code).send(reply);
     });
 
@@ -224,6 +251,76 @@ export function setupRoutes(server: FastifyInstance) {
         return {success: true, data: data};
     }
 
+
+    async function handleGetNotifications(params: { uuid?: string }): Promise<Process<any>> {
+        const {uuid} = params;
+        const {data, error} = await server.supabase
+            .from("notifications")
+            .select("*")
+            .eq("recipient", uuid)
+            .order("created_at", {ascending: false})
+            .limit(50);
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleUnreadCount(params: { uuid?: string }): Promise<Process<any>> {
+        const {uuid} = params;
+        const {count, error} = await server.supabase
+            .from("notifications")
+            .select("*", {count: "exact", head: true})
+            .eq("recipient", uuid)
+            .eq("read", false);
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: {count: count ?? 0} as any};
+    }
+
+    async function handleCreateNotification(req: NewNotification): Promise<Process<any>> {
+        const {recipient, type, title, body, climb, actor} = req;
+        const {data, error} = await server.supabase.from("notifications").insert([{
+            recipient,
+            type,
+            title,
+            body: body ?? null,
+            climb: climb ?? null,
+            actor: actor ?? null,
+        }]).select();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleMarkRead(params: { id?: string }): Promise<Process<any>> {
+        const {id} = params;
+        const {data, error} = await server.supabase
+            .from("notifications")
+            .update({read: true})
+            .eq("id", id)
+            .select();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleMarkAllRead(params: { uuid?: string }): Promise<Process<any>> {
+        const {uuid} = params;
+        const {data, error} = await server.supabase
+            .from("notifications")
+            .update({read: true})
+            .eq("recipient", uuid)
+            .eq("read", false)
+            .select();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
 
     async function packageResponse<O>(handler: () => Promise<Process<O>>,): Promise<ReplyConfig<O>> {
         const result = await handler();

--- a/frontend/src/components/HomeRow.tsx
+++ b/frontend/src/components/HomeRow.tsx
@@ -1,5 +1,6 @@
 import {type NavigateFunction, useNavigate} from "react-router-dom";
 import '../pages/styles/homerow.css'
+import NotificationBell from "./NotificationBell.tsx";
 
 
 export default function HomeRow() {
@@ -22,6 +23,7 @@ export default function HomeRow() {
                 </svg>
                 <p>Add Climb</p>
             </div>
+            <NotificationBell/>
             <div className={'profile-button'} onClick={() => navigate("/profile")}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
                      className="bi bi-person" viewBox="0 0 16 16" >

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,0 +1,51 @@
+import {useEffect, useState} from "react";
+import {type NavigateFunction, useNavigate} from "react-router-dom";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import {BACKEND_URL} from "../lib/types.ts";
+import "../pages/styles/notificationbell.css";
+
+export default function NotificationBell() {
+    const [unread, setUnread] = useState<number>(0);
+    const navigate: NavigateFunction = useNavigate();
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const fetchCount = async () => {
+            const {data: {user}} = await supabaseClient.auth.getUser();
+            if (!user) return;
+            try {
+                const response = await fetch(`${BACKEND_URL}/notifications/${user.id}/unread-count`);
+                const payload = await response.json();
+                if (!cancelled && payload.success) {
+                    setUnread(payload.data?.count ?? 0);
+                }
+            } catch (error) {
+                console.log("Failed to fetch unread notification count", error);
+            }
+        };
+
+        fetchCount();
+        const interval = setInterval(fetchCount, 30_000);
+
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, []);
+
+    return (
+        <div className={'notification-button'} onClick={() => navigate("/notifications")}>
+            <div className={'bell-wrapper'}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
+                     className="bi bi-bell" viewBox="0 0 16 16">
+                    <path d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2M8 1.918l-.797.161A4 4 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4 4 0 0 0-3.203-3.92zM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5 5 0 0 1 13 6c0 .88.32 4.2 1.22 6"/>
+                </svg>
+                {unread > 0 && (
+                    <span className={'notification-badge'}>{unread > 99 ? "99+" : unread}</span>
+                )}
+            </div>
+            <p>Alerts</p>
+        </div>
+    );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,29 @@ export interface Log {
     climb: number;
 }
 
+export type NotificationType = "new_climb" | "climb_comment" | "climb_logged" | "system";
+
+export interface Notification {
+    id: number;
+    recipient: string;
+    type: NotificationType;
+    title: string;
+    body: string | null;
+    climb: number | null;
+    actor: string | null;
+    read: boolean;
+    created_at: string;
+}
+
+export interface NewNotification {
+    recipient: string;
+    type: NotificationType;
+    title: string;
+    body?: string;
+    climb?: number;
+    actor?: string;
+}
+
 export const BACKEND_URL: string = 'http://localhost:8000';
 export const FRONTEND_URL: string = 'http://localhost:5173';
 

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import Notifications from "./notifications.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -53,6 +54,14 @@ function Root() {
                 element={
                     <ProtectedRoute session={session}>
                         <Profile/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/notifications"
+                element={
+                    <ProtectedRoute session={session}>
+                        <Notifications/>
                     </ProtectedRoute>
                 }
             />

--- a/frontend/src/pages/notifications.tsx
+++ b/frontend/src/pages/notifications.tsx
@@ -1,0 +1,113 @@
+import {useEffect, useState} from "react";
+import type {User} from "@supabase/supabase-js";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import {BACKEND_URL, type Notification} from "../lib/types.ts";
+import HomeRow from "../components/HomeRow.tsx";
+import "./styles/notifications.css";
+
+function formatTimeAgo(iso: string): string {
+    const created = new Date(iso).getTime();
+    const diffSeconds = Math.max(0, Math.floor((Date.now() - created) / 1000));
+    if (diffSeconds < 60) return `${diffSeconds}s ago`;
+    const diffMinutes = Math.floor(diffSeconds / 60);
+    if (diffMinutes < 60) return `${diffMinutes}m ago`;
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return new Date(iso).toLocaleDateString();
+}
+
+export default function Notifications() {
+    const [user, setUser] = useState<User>();
+    const [notifications, setNotifications] = useState<Notification[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const fetchUser = async () => {
+            const {data: {user}} = await supabaseClient.auth.getUser();
+            setUser(user ?? undefined);
+        };
+        fetchUser();
+    }, []);
+
+    useEffect(() => {
+        if (!user?.id) return;
+        const fetchNotifications = async () => {
+            setLoading(true);
+            try {
+                const response = await fetch(`${BACKEND_URL}/notifications/${user.id}`);
+                const payload = await response.json();
+                if (payload.success) {
+                    setNotifications(payload.data as Notification[]);
+                }
+            } catch (error) {
+                console.log("Failed to fetch notifications", error);
+            }
+            setLoading(false);
+        };
+        fetchNotifications();
+    }, [user]);
+
+    const markRead = async (id: number) => {
+        setNotifications((prev) => prev.map((n) => (n.id === id ? {...n, read: true} : n)));
+        try {
+            await fetch(`${BACKEND_URL}/notifications/${id}/read`, {method: "PATCH"});
+        } catch (error) {
+            console.log("Failed to mark notification as read", error);
+        }
+    };
+
+    const markAllRead = async () => {
+        if (!user?.id) return;
+        setNotifications((prev) => prev.map((n) => ({...n, read: true})));
+        try {
+            await fetch(`${BACKEND_URL}/notifications/${user.id}/read-all`, {method: "PATCH"});
+        } catch (error) {
+            console.log("Failed to mark all notifications as read", error);
+        }
+    };
+
+    const hasUnread = notifications.some((n) => !n.read);
+
+    return (
+        <>
+            <div className={'notifications-page'}>
+                <div className={'notifications-heading'}>
+                    <h1>Notifications</h1>
+                    <button
+                        className={'mark-all-read'}
+                        onClick={markAllRead}
+                        disabled={!hasUnread}
+                    >
+                        Mark all read
+                    </button>
+                </div>
+
+                <div className={'notifications-list'}>
+                    {notifications.length > 0 ? (
+                        notifications.map((notification) => (
+                            <div
+                                key={notification.id}
+                                className={`notification-item ${notification.read ? '' : 'unread'}`}
+                                onClick={() => !notification.read && markRead(notification.id)}
+                            >
+                                <div className={'notification-content'}>
+                                    <h3>{notification.title}</h3>
+                                    {notification.body && <p>{notification.body}</p>}
+                                    <span className={'notification-time'}>
+                                        {formatTimeAgo(notification.created_at)}
+                                    </span>
+                                </div>
+                                {!notification.read && <div className={'unread-dot'}/>}
+                            </div>
+                        ))
+                    ) : (
+                        loading ? <p>Loading...</p> : <p>No notifications yet</p>
+                    )}
+                </div>
+            </div>
+            <HomeRow/>
+        </>
+    );
+}

--- a/frontend/src/pages/styles/homerow.css
+++ b/frontend/src/pages/styles/homerow.css
@@ -17,7 +17,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-right: 10vw;
+    margin-right: 6vw;
 }
 
 .add-button {
@@ -30,7 +30,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-left: 10vw;
+    margin-left: 6vw;
 }
 
 .home-row p {

--- a/frontend/src/pages/styles/notificationbell.css
+++ b/frontend/src/pages/styles/notificationbell.css
@@ -1,0 +1,39 @@
+.notification-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 6vw;
+    cursor: pointer;
+}
+
+.bell-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.notification-badge {
+    position: absolute;
+    top: -2px;
+    right: -6px;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 9px;
+    background-color: #d43f3a;
+    color: white;
+    font-size: 11px;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid #EDCDB7;
+    box-sizing: content-box;
+}
+
+@media only screen and (min-width: 1500px) {
+    .notification-button {
+        margin-left: 20px;
+    }
+}

--- a/frontend/src/pages/styles/notifications.css
+++ b/frontend/src/pages/styles/notifications.css
@@ -1,0 +1,100 @@
+.notifications-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 24px 16px 96px 16px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.notifications-heading {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    max-width: 720px;
+    margin-bottom: 16px;
+}
+
+.notifications-heading h1 {
+    margin: 0;
+}
+
+.mark-all-read {
+    background-color: #EDCDB7;
+    border: 2px solid black;
+    border-radius: 16px;
+    padding: 8px 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.mark-all-read:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.notifications-list {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 720px;
+    gap: 12px;
+}
+
+.notification-item {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border: 2px solid black;
+    border-radius: 12px;
+    background-color: #ffffff;
+    cursor: pointer;
+}
+
+.notification-item.unread {
+    background-color: #EDCDB7;
+}
+
+.notification-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+}
+
+.notification-content h3 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.notification-content p {
+    margin: 0;
+    font-size: 14px;
+    color: #333;
+}
+
+.notification-time {
+    font-size: 12px;
+    color: #666;
+    margin-top: 4px;
+}
+
+.unread-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: #d43f3a;
+    margin-left: 12px;
+    margin-top: 6px;
+    flex-shrink: 0;
+}
+
+@media only screen and (min-width: 1500px) {
+    .notifications-page {
+        padding-left: 170px;
+    }
+}

--- a/migrations/0001_notifications.sql
+++ b/migrations/0001_notifications.sql
@@ -1,0 +1,35 @@
+-- Notifications table: stores per-user in-app notifications surfaced in the bell menu.
+create type notification_type as enum ('new_climb', 'climb_comment', 'climb_logged', 'system');
+
+create table if not exists notifications (
+    id bigserial primary key,
+    recipient uuid not null references auth.users(id) on delete cascade,
+    type notification_type not null default 'system',
+    title text not null,
+    body text,
+    climb bigint references climbs(id) on delete cascade,
+    actor uuid references auth.users(id) on delete set null,
+    read boolean not null default false,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists notifications_recipient_created_idx
+    on notifications (recipient, created_at desc);
+
+create index if not exists notifications_recipient_unread_idx
+    on notifications (recipient)
+    where read = false;
+
+alter table notifications enable row level security;
+
+create policy "Users can view their own notifications"
+    on notifications for select
+    using (auth.uid() = recipient);
+
+create policy "Users can update their own notifications"
+    on notifications for update
+    using (auth.uid() = recipient);
+
+create policy "Service role can insert notifications"
+    on notifications for insert
+    with check (true);


### PR DESCRIPTION
## Summary

Adds an in-app notification center so climbers can see activity relevant to them (a new climb was set in their gym, someone commented on a climb they logged, etc.).

### What changed

**Database** — new `migrations/0001_notifications.sql`:
- `notifications` table: `id`, `recipient` (FK → `auth.users`), `type` (enum: `new_climb | climb_comment | climb_logged | system`), `title`, `body`, `climb` (FK → `climbs`), `actor` (FK → `auth.users`), `read`, `created_at`.
- Indexes on `(recipient, created_at desc)` and a partial index on unread.
- RLS policies: users can only select/update their own rows; service role (backend) can insert.

**Backend** (`backend/src/routes.ts`):
- `GET    /notifications/:uuid` — list a user's most recent 50 notifications.
- `GET    /notifications/:uuid/unread-count` — return `{ count }` for the badge.
- `POST   /notifications` — create a notification (called by producers like a new-climb hook or a comment handler — hook wiring is a follow-up).
- `PATCH  /notifications/:id/read` — mark one read.
- `PATCH  /notifications/:uuid/read-all` — mark all of a user's unread read.

All routes follow the existing `packageResponse` pattern. Types added to `frontend/src/lib/types.ts` (`Notification`, `NewNotification`, `NotificationType`).

**Frontend**:
- `NotificationBell` component — bell icon with an unread-count badge, polls `/unread-count` every 30s, lives in the nav next to the other `HomeRow` buttons.
- `/notifications` route — scrollable list of notifications with "mark all read", individual-item mark-as-read on click, and relative time stamps.
- Styling follows the repo's existing CSS-file-per-page convention (not Tailwind classes inline) to match `homerow.css` / `climbelement.css`.
- `HomeRow` spacing tightened from `10vw` to `6vw` to fit the new bell without cramping the existing icons.

### Why

Users currently have no way to discover activity relevant to them — new climbs show up on Home but there's no signal when someone engages with a climb they've logged. A lightweight bell/badge pattern is the cheapest way to surface this without redesigning the nav.

### Assumptions

- Authorization for reads is handled by Supabase RLS (the bell fetches by `user.id` from the Supabase session client-side; the backend uses the service-role key). A hardened version would sign requests and verify the recipient on the server; that's out of scope for this PR.
- Event producers (a trigger / hook that creates a notification when a climb is logged or a comment is posted) are **not** wired up here. The POST endpoint exists so those hooks can be added incrementally — a natural next PR adds a Supabase trigger on `completed_climbs` insert.
- Reply-typing in `backend/src/routes.ts` was kept loose to match existing handlers. The file has pre-existing TypeScript errors at HEAD (25 on `main` before this change; 25 after) — handlers return `Promise<Task>` where `Task = Process<void>`, which conflicts with returning array data. I did not fix those to keep the diff focused on the notification feature.

### Follow-ups

- [ ] Run the migration in Supabase: `psql ... -f migrations/0001_notifications.sql` (or execute in the Supabase SQL editor).
- [ ] Add a Supabase trigger on `climbs` insert that fans out a `new_climb` notification to every user who has logged at least one climb at that gym.
- [ ] Add a comments feature (currently no climb-comments exist) and fire a `climb_comment` notification on insert.
- [ ] Replace the 30-second polling in `NotificationBell` with a Supabase realtime subscription on the `notifications` table filtered by `recipient = auth.uid()`.
- [ ] Server-side authorization: have the backend verify the caller owns `:uuid` via a Supabase JWT instead of trusting the URL param.
- [ ] Address the pre-existing TypeScript strictness errors in `backend/src/routes.ts` as a separate cleanup PR.

### No new env vars / credentials

Uses the existing `SUPABASE_URL` / `SUPABASE_KEY` on the backend and the existing publishable key on the frontend.