### PR TITLE
feat: system-aware dark mode toggle

### DIFF
--- a/frontend/src/components/HomeRow.tsx
+++ b/frontend/src/components/HomeRow.tsx
@@ -1,5 +1,6 @@
 import {type NavigateFunction, useNavigate} from "react-router-dom";
 import '../pages/styles/homerow.css'
+import ThemeToggle from "./ThemeToggle.tsx";
 
 
 export default function HomeRow() {
@@ -29,6 +30,9 @@ export default function HomeRow() {
                         d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6m2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0m4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4m-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10s-3.516.68-4.168 1.332c-.678.678-.83 1.418-.832 1.664z"/>
                 </svg>
                 <p>Profile</p>
+            </div>
+            <div className={'theme-toggle-wrap'}>
+                <ThemeToggle/>
             </div>
         </div>
     );

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,66 @@
+import {useTheme} from "../util/useTheme";
+import type {ThemePreference} from "../util/themeContext";
+
+const OPTIONS: {value: ThemePreference; label: string; icon: React.ReactNode}[] = [
+    {
+        value: "light",
+        label: "Light",
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/>
+            </svg>
+        ),
+    },
+    {
+        value: "system",
+        label: "System",
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2h-4l.25 1.5h.75a.5.5 0 0 1 0 1h-6a.5.5 0 0 1 0-1h.75L6 12H2a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1z"/>
+            </svg>
+        ),
+    },
+    {
+        value: "dark",
+        label: "Dark",
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
+            </svg>
+        ),
+    },
+];
+
+export default function ThemeToggle({className = ""}: {className?: string}) {
+    const {preference, setPreference} = useTheme();
+
+    return (
+        <div
+            role="radiogroup"
+            aria-label="Theme"
+            className={`inline-flex items-center gap-1 rounded-full border-2 border-black bg-[#EDCDB7] p-1 text-black dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 ${className}`}
+        >
+            {OPTIONS.map(opt => {
+                const active = preference === opt.value;
+                return (
+                    <button
+                        key={opt.value}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        aria-label={opt.label}
+                        title={opt.label}
+                        onClick={() => setPreference(opt.value)}
+                        className={`flex h-7 w-7 items-center justify-center rounded-full transition-colors cursor-pointer ${
+                            active
+                                ? "bg-white text-black dark:bg-slate-200 dark:text-slate-900"
+                                : "text-black/70 hover:bg-white/60 dark:text-slate-300 dark:hover:bg-slate-700"
+                        }`}
+                    >
+                        {opt.icon}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,24 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+@theme {
+    --color-surface: #f7f8f0;
+    --color-surface-alt: #EDCDB7;
+    --color-card: #ECEDED;
+    --color-ink: #111111;
+    --color-surface-dark: #0f172a;
+    --color-surface-alt-dark: #1e293b;
+    --color-card-dark: #0b1220;
+    --color-ink-dark: #e5e7eb;
+}
+
+html,
+body,
+#root {
+    height: 100%;
+}
+
+html.dark {
+    color-scheme: dark;
+}

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,6 +1,7 @@
 import { supabaseClient} from "../util/supabaseClient.ts";
 import "./styles/login.css";
 import {FRONTEND_URL} from "../lib/types.ts";
+import ThemeToggle from "../components/ThemeToggle.tsx";
 
 export default function LoginPage() {
 
@@ -18,6 +19,9 @@ export default function LoginPage() {
 
     return (
         <>
+            <div className="fixed right-4 top-4 z-20">
+                <ThemeToggle/>
+            </div>
             <div className="login-page">
                 <h1>Clapp</h1>
                 <h4>UNC's Mountain Project</h4>

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -2,13 +2,18 @@ import {createRoot} from 'react-dom/client';
 import {BrowserRouter, Route, Routes} from "react-router";
 import {useEffect, useState} from "react";
 import type {Session} from "@supabase/supabase-js";
+import "../index.css";
 import { supabaseClient} from "../util/supabaseClient.ts";
+import {ThemeProvider} from "../util/theme.tsx";
+import {applyInitialTheme} from "../util/themeRuntime.ts";
 import LoginPage from "./login.tsx";
 import ProtectedRoute from "./../components/ProtectedRoute";
 
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+
+applyInitialTheme();
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -29,7 +34,7 @@ function Root() {
 
     if (loading) return <div> Loading...</div>
 
-    return (<BrowserRouter>
+    return (<ThemeProvider><BrowserRouter>
         <Routes>
             <Route index element={<LoginPage/>}/>
             <Route
@@ -57,7 +62,7 @@ function Root() {
                 }
             />
         </Routes>
-    </BrowserRouter>);
+    </BrowserRouter></ThemeProvider>);
 
 }
 

--- a/frontend/src/pages/styles/SearchBar.css
+++ b/frontend/src/pages/styles/SearchBar.css
@@ -20,6 +20,29 @@
     height: fit-content;
 }
 
+html.dark .search-bar {
+    background-color: #1e293b;
+    border-color: #e5e7eb;
+    color: #e5e7eb;
+}
+
+html.dark .search-bar input {
+    color: #e5e7eb;
+}
+
+html.dark .search-bar input::placeholder {
+    color: #94a3b8;
+}
+
+html.dark .search-bar svg {
+    color: #e5e7eb;
+}
+
+html.dark .filter.enabled {
+    background-color: #334155;
+    border-color: #e5e7eb;
+}
+
 .search-bar input {
     flex: 1;
     border: none;

--- a/frontend/src/pages/styles/climbelement.css
+++ b/frontend/src/pages/styles/climbelement.css
@@ -28,6 +28,17 @@
     border-color: #3498db;
 }
 
+html.dark .climb-container {
+    background-color: #1e293b;
+    border-color: #475569;
+    color: #e5e7eb;
+}
+
+html.dark .climb-container.highlighted {
+    outline-color: #60a5fa;
+    border-color: #60a5fa;
+}
+
 h1 {
     margin: 6px;
     font-size: 24px;

--- a/frontend/src/pages/styles/filterclimbs.css
+++ b/frontend/src/pages/styles/filterclimbs.css
@@ -61,6 +61,29 @@
     display: none;
 }
 
+html.dark .advanced-search-bar.show {
+    background-color: #1e293b;
+    border-color: #e5e7eb;
+    color: #e5e7eb;
+}
+
+html.dark .advanced-search-bar input,
+html.dark .advanced-search-bar select {
+    background-color: #0f172a;
+    color: #e5e7eb;
+    border-color: #475569;
+}
+
+html.dark .advanced-search-bar button {
+    background-color: #334155;
+    color: #e5e7eb;
+    border-color: #e5e7eb;
+}
+
+html.dark .archived-climbs {
+    border-color: #e5e7eb;
+}
+
 .filter-r1 {
     display: flex;
     flex-direction: row;

--- a/frontend/src/pages/styles/home.css
+++ b/frontend/src/pages/styles/home.css
@@ -40,6 +40,17 @@ body {
     background-color: #B7D7ED;
 }
 
+html.dark body {
+    background-color: #0b1220;
+    color: #e5e7eb;
+}
+
+html.dark .log-button {
+    background-color: #7c4a2a;
+    border-color: #e5e7eb;
+    color: #f8fafc;
+}
+
 .climbs {
     width: fit-content;
     overflow-y: scroll;

--- a/frontend/src/pages/styles/homerow.css
+++ b/frontend/src/pages/styles/homerow.css
@@ -13,6 +13,22 @@
     z-index:3;
 }
 
+html.dark .home-row {
+    background-color: #1e293b;
+    border-top-color: #e5e7eb;
+    color: #e5e7eb;
+}
+
+html.dark .home-row svg {
+    color: #e5e7eb;
+}
+
+.theme-toggle-wrap {
+    margin-left: 10vw;
+    display: flex;
+    align-items: center;
+}
+
 .home-button {
     display: flex;
     flex-direction: row;
@@ -67,6 +83,16 @@
 
     .profile-button {
         margin-left: 20px;
+    }
+
+    .theme-toggle-wrap {
+        margin-left: 20px;
+        margin-top: auto;
+        margin-bottom: 16px;
+    }
+
+    html.dark .home-row {
+        border-right-color: #e5e7eb;
     }
 }
 

--- a/frontend/src/pages/styles/login.css
+++ b/frontend/src/pages/styles/login.css
@@ -59,3 +59,24 @@ img {
     margin-top: 12vw;
     padding: 16px;
 }
+
+html.dark body {
+    background-color: #0f172a;
+    color: #e5e7eb;
+}
+
+html.dark .login-page,
+html.dark .login-page h1,
+html.dark .login-page h4 {
+    color: #e5e7eb;
+}
+
+html.dark .google-btn {
+    background-color: #1e293b;
+    color: #e5e7eb;
+    border-color: #334155;
+}
+
+html.dark .google-btn:hover {
+    background-color: #334155;
+}

--- a/frontend/src/pages/styles/newclimb.css
+++ b/frontend/src/pages/styles/newclimb.css
@@ -87,3 +87,33 @@
         gap: 8px 16px;
     }
 }
+
+html.dark body {
+    background-color: #0b1220;
+    color: #e5e7eb;
+}
+
+html.dark .add-page,
+html.dark .add-page label,
+html.dark .add-page p {
+    color: #e5e7eb;
+}
+
+html.dark .add-page h1 {
+    background-color: #1e293b;
+    border-color: #e5e7eb;
+    color: #e5e7eb;
+}
+
+html.dark .add-form input,
+html.dark .add-form select {
+    background-color: #1e293b;
+    color: #e5e7eb;
+    border-color: #475569;
+}
+
+html.dark .add-form-button {
+    background-color: #7c4a2a;
+    color: #f8fafc;
+    border-color: #e5e7eb;
+}

--- a/frontend/src/pages/styles/profile.css
+++ b/frontend/src/pages/styles/profile.css
@@ -35,6 +35,23 @@
     border-radius: 50%;
 }
 
+html.dark body {
+    background-color: #0b1220;
+    color: #e5e7eb;
+}
+
+html.dark .profile-page,
+html.dark .profile-page h1 {
+    color: #e5e7eb;
+}
+
+html.dark .completed-climbs,
+html.dark .user-info {
+    background-color: #1e293b;
+    border-color: #e5e7eb;
+    color: #e5e7eb;
+}
+
 .logged-climbs {
     width: fit-content;
     overflow-y: scroll;
@@ -42,7 +59,6 @@
     z-index: -1;
     margin-bottom: 64px;
 }
-.
 
 @media only screen and (min-width: 600px) {
     .climbs-profile {

--- a/frontend/src/util/theme.tsx
+++ b/frontend/src/util/theme.tsx
@@ -1,0 +1,53 @@
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    useSyncExternalStore,
+    type ReactNode,
+} from "react";
+import {ThemeContext, type ResolvedTheme, type ThemeContextValue, type ThemePreference} from "./themeContext";
+import {
+    STORAGE_KEY,
+    applyTheme,
+    getServerSnapshot,
+    getSystemSnapshot,
+    readStoredPreference,
+    subscribeToSystem,
+} from "./themeRuntime";
+
+export function ThemeProvider({children}: {children: ReactNode}) {
+    const [preference, setPreferenceState] = useState<ThemePreference>(() => readStoredPreference());
+    const systemTheme = useSyncExternalStore(subscribeToSystem, getSystemSnapshot, getServerSnapshot);
+
+    const resolved: ResolvedTheme = preference === "system" ? systemTheme : preference;
+
+    useEffect(() => {
+        applyTheme(resolved);
+    }, [resolved]);
+
+    const setPreference = useCallback((next: ThemePreference) => {
+        if (next === "system") {
+            window.localStorage.removeItem(STORAGE_KEY);
+        } else {
+            window.localStorage.setItem(STORAGE_KEY, next);
+        }
+        setPreferenceState(next);
+    }, []);
+
+    const toggle = useCallback(() => {
+        setPreferenceState(prev => {
+            const currentResolved = prev === "system" ? getSystemSnapshot() : prev;
+            const next: ThemePreference = currentResolved === "dark" ? "light" : "dark";
+            window.localStorage.setItem(STORAGE_KEY, next);
+            return next;
+        });
+    }, []);
+
+    const value = useMemo<ThemeContextValue>(
+        () => ({preference, resolved, setPreference, toggle}),
+        [preference, resolved, setPreference, toggle],
+    );
+
+    return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}

--- a/frontend/src/util/themeContext.ts
+++ b/frontend/src/util/themeContext.ts
@@ -1,0 +1,13 @@
+import {createContext} from "react";
+
+export type ThemePreference = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+export interface ThemeContextValue {
+    preference: ThemePreference;
+    resolved: ResolvedTheme;
+    setPreference: (next: ThemePreference) => void;
+    toggle: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);

--- a/frontend/src/util/themeRuntime.ts
+++ b/frontend/src/util/themeRuntime.ts
@@ -1,0 +1,39 @@
+import type {ResolvedTheme, ThemePreference} from "./themeContext";
+
+export const STORAGE_KEY = "clapp.theme";
+
+export function readStoredPreference(): ThemePreference {
+    if (typeof window === "undefined") return "system";
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "light" || raw === "dark" || raw === "system") return raw;
+    return "system";
+}
+
+export function subscribeToSystem(callback: () => void): () => void {
+    if (typeof window === "undefined" || !window.matchMedia) return () => {};
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    media.addEventListener("change", callback);
+    return () => media.removeEventListener("change", callback);
+}
+
+export function getSystemSnapshot(): ResolvedTheme {
+    if (typeof window === "undefined" || !window.matchMedia) return "light";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function getServerSnapshot(): ResolvedTheme {
+    return "light";
+}
+
+export function applyTheme(resolved: ResolvedTheme) {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    root.classList.toggle("dark", resolved === "dark");
+    root.dataset.theme = resolved;
+}
+
+export function applyInitialTheme() {
+    const pref = readStoredPreference();
+    const resolved: ResolvedTheme = pref === "system" ? getSystemSnapshot() : pref;
+    applyTheme(resolved);
+}

--- a/frontend/src/util/useTheme.ts
+++ b/frontend/src/util/useTheme.ts
@@ -1,0 +1,8 @@
+import {useContext} from "react";
+import {ThemeContext, type ThemeContextValue} from "./themeContext";
+
+export function useTheme(): ThemeContextValue {
+    const ctx = useContext(ThemeContext);
+    if (!ctx) throw new Error("useTheme must be used within a ThemeProvider");
+    return ctx;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
   plugins: [
     react(),
+    tailwindcss(),
     VitePWA({
       registerType: 'autoUpdate',
       manifest: {


### PR DESCRIPTION
## Summary

- Adds a frontend dark-mode system with three states — **light / system / dark** — persisted in `localStorage` under `clapp.theme`.
- Wires up Tailwind v4 with class-based dark mode (`.dark` class on `<html>`) so components can use Tailwind `dark:` variants.
- Adds a `ThemeToggle` widget to the nav row (visible on Home / Log Climb / Profile) and to the login screen so it's reachable everywhere.
- Extends each page's existing CSS with `.dark` selector overrides (backgrounds, card surfaces, borders, form inputs, the Google sign-in button, etc.) so all current UI tracks the active theme.
- Applies the stored preference *before* React mounts (via `applyInitialTheme()` in `main.tsx`) to avoid a light-mode flash on first paint.
- Subscribes to `prefers-color-scheme` via `useSyncExternalStore` so users who leave the toggle on "System" get live updates when they change their OS theme.

## Why

The app is currently locked to a single light palette. Users on dark-mode OSes get a jarring bright screen, and there was no way to pick a theme. This PR introduces a standard three-state toggle (the pattern users know from GitHub / VS Code / most modern apps) and plumbs Tailwind's dark-mode story through the codebase so future components can just add `dark:` utilities without reinventing state.

## Implementation notes

- `frontend/src/index.css` is a new entry stylesheet that pulls in Tailwind (`@import "tailwindcss"`) and registers `@custom-variant dark (&:where(.dark, .dark *))`. Imported once at the top of `main.tsx`.
- `@tailwindcss/vite` was already in `package.json` but not wired into `vite.config.ts`; this PR adds the plugin.
- Theme state is split across four small files to keep `react-refresh/only-export-components` happy:
  - `util/themeContext.ts` — types + `React.createContext`
  - `util/useTheme.ts` — the consumer hook
  - `util/theme.tsx` — the `<ThemeProvider>` component
  - `util/themeRuntime.ts` — SSR-safe pure helpers (`readStoredPreference`, `applyTheme`, `applyInitialTheme`, `matchMedia` subscribe/snapshot)
- Existing page CSS files (`home.css`, `login.css`, `profile.css`, `newclimb.css`, `homerow.css`, `climbelement.css`, `SearchBar.css`, `filterclimbs.css`) gained `html.dark ...` override blocks. This parallels Tailwind's `dark:` variants but works for the project's existing hand-written classes without a rewrite.
- The `ThemeToggle` component itself is written in Tailwind utility classes with `dark:` variants, demonstrating the new setup.

## Out-of-scope fixes

- `frontend/src/pages/styles/profile.css` had a pre-existing stray `.` token on line 45 that lightningcss (bundled with `@tailwindcss/vite`) rejects as invalid CSS. Since adding Tailwind is what introduced lightningcss to this pipeline, the typo is fixed in this PR — one-character delete — rather than punted to a separate PR.

## Assumptions / follow-ups

- **Pre-existing TypeScript errors are not fixed here.** `main` already fails `tsc -b` with ~20 unrelated errors (implicit `any` in `ClimbElement` / `FilterClimbs` / `SearchBar` / `home.tsx`, `Session | null` not assignable to `ProtectedRoute`'s non-nullable `Session`, etc.). This PR introduces no new TS errors. `vite build` succeeds; `tsc -b` fails on the same files it already fails on. Happy to tackle those in a follow-up if desired.
- **Pre-existing ESLint errors are likewise untouched** in files this PR doesn't modify. The files this PR adds or touches lint clean.
- **No DB or backend changes.** Preference lives purely client-side in `localStorage`; if a future feature wants server-persisted user preferences, that would be a separate migration + route.
- **No new env vars or API keys required.**
- **Manual QA recommended on each page** (login, home, log-climb, profile, filter drawer) across light / dark / system. I couldn't exercise the running app in the CI environment.