### PR TITLE
feat: climb-comments: add comment thread on climb detail

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -11,7 +11,7 @@ import {
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
+    BOULDER_GRADES, type Log, type NewComment
 } from "../../frontend/src/lib/types.ts";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
@@ -33,6 +33,14 @@ export function setupRoutes(server: FastifyInstance) {
     }>("/climbs", async (req, res) => {
         const {reply: result, code} = await packageResponse(() => handleGetClimbs());
         return res.status(code).send(result);
+    });
+
+    server.get<{
+        Params: { id: string };
+        Reply: any | { error: string };
+    }>("/climbs/:id", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleGetClimb(req.params));
+        res.status(code).send(reply);
     });
 
     server.post<{
@@ -67,6 +75,23 @@ export function setupRoutes(server: FastifyInstance) {
         Reply: BaseReply<void>;
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.get<{
+        Params: { id: string };
+        Reply: any[] | { error: string };
+    }>("/climbs/:id/comments", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleGetComments(req.params));
+        res.status(code).send(reply);
+    });
+
+    server.post<{
+        Params: { id: string };
+        Body: NewComment;
+        Reply: BaseReply<void>;
+    }>("/climbs/:id/comments", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleNewComment(req.params, req.body));
         res.status(code).send(reply);
     });
 
@@ -210,6 +235,68 @@ export function setupRoutes(server: FastifyInstance) {
                 return gradeList.filter(grade => BOULDER_GRADES[grade] <= BOULDER_GRADES[filterGrade]);
             }
         }
+    }
+
+    async function handleGetClimb(params: { id?: string }): Promise<Task> {
+        const climbId = Number(params.id);
+        if (!params.id || Number.isNaN(climbId)) {
+            return {success: false, error: new Error("Invalid climb id"), code: 400};
+        }
+        const {data, error} = await server.supabase
+            .from("climbs")
+            .select("*")
+            .eq("id", climbId)
+            .maybeSingle();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        if (!data) {
+            return {success: false, error: new Error("Climb not found"), code: 404};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleGetComments(params: { id?: string }): Promise<Task> {
+        const {id} = params;
+        const climbId = Number(id);
+        if (!id || Number.isNaN(climbId)) {
+            return {success: false, error: new Error("Invalid climb id"), code: 400};
+        }
+        const {data, error} = await server.supabase
+            .from("comments")
+            .select("*")
+            .eq("climb", climbId)
+            .order("created_at", {ascending: true});
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleNewComment(params: { id?: string }, req: NewComment): Promise<Task> {
+        const climbId = Number(params.id);
+        if (!params.id || Number.isNaN(climbId)) {
+            return {success: false, error: new Error("Invalid climb id"), code: 400};
+        }
+        const {author, authorName, authorAvatar, body} = req;
+        const trimmed = typeof body === "string" ? body.trim() : "";
+        if (!author || !trimmed) {
+            return {success: false, error: new Error("author and body are required"), code: 400};
+        }
+        if (trimmed.length > 2000) {
+            return {success: false, error: new Error("body exceeds 2000 characters"), code: 400};
+        }
+        const {data, error} = await server.supabase.from("comments").insert([{
+            climb: climbId,
+            author: author,
+            author_name: authorName ?? null,
+            author_avatar: authorAvatar ?? null,
+            body: trimmed,
+        }]).select();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
     }
 
     async function handleLog(req: Log): Promise<Task> {

--- a/frontend/src/components/ClimbElement.tsx
+++ b/frontend/src/components/ClimbElement.tsx
@@ -1,6 +1,6 @@
 import {type Climb, ROUTE_COLORS} from "../lib/types.ts";
 import '../pages/styles/climbelement.css'
-import {useState} from "react";
+import {useNavigate} from "react-router-dom";
 
 interface ClimbElementProps {
     jsonClimb: Climb;
@@ -10,6 +10,7 @@ interface ClimbElementProps {
 }
 
 export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: ClimbElementProps) {
+    const navigate = useNavigate();
     const climbAdapter = (data) => {
         return {
             name: data.name,
@@ -54,6 +55,16 @@ export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: Cl
             <h1>{difficulty}</h1>
             <div className={'cooler-circle'} style={{backgroundColor: ROUTE_COLORS[color]}}></div>
             <h4>{formatLocalHeader(dateSet)}</h4>
+            <button
+                type={"button"}
+                className={'climb-comments-link'}
+                onClick={(event) => {
+                    event.stopPropagation();
+                    navigate(`/climb/${climbId}`);
+                }}
+            >
+                Comments
+            </button>
         </div>
     </div>);
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,24 @@ export interface Log {
     climb: number;
 }
 
+export interface Comment {
+    id: number;
+    climb: number;
+    author: string;
+    author_name: string | null;
+    author_avatar: string | null;
+    body: string;
+    created_at: string;
+}
+
+export interface NewComment {
+    climb: number;
+    author: string;
+    authorName?: string | null;
+    authorAvatar?: string | null;
+    body: string;
+}
+
 export const BACKEND_URL: string = 'http://localhost:8000';
 export const FRONTEND_URL: string = 'http://localhost:5173';
 

--- a/frontend/src/pages/climbdetail.tsx
+++ b/frontend/src/pages/climbdetail.tsx
@@ -1,0 +1,172 @@
+import {useEffect, useState} from "react";
+import {useNavigate, useParams} from "react-router-dom";
+import type {User} from "@supabase/supabase-js";
+import HomeRow from "../components/HomeRow.tsx";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import {BACKEND_URL, type Comment, ROUTE_COLORS} from "../lib/types.ts";
+
+type ClimbRecord = {
+    id: number;
+    name: string;
+    difficulty: string;
+    type: string;
+    color: string;
+    setter: string;
+    gym: string;
+    date_set?: string;
+};
+import {toast, ToastContainer} from "react-toastify";
+import "./styles/climbdetail.css";
+
+const MAX_LENGTH = 2000;
+
+export default function ClimbDetail() {
+    const {id} = useParams<{id: string}>();
+    const navigate = useNavigate();
+    const [climb, setClimb] = useState<ClimbRecord | null>(null);
+    const [comments, setComments] = useState<Comment[]>([]);
+    const [user, setUser] = useState<User>();
+    const [body, setBody] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [submitting, setSubmitting] = useState(false);
+
+    useEffect(() => {
+        const fetchUser = async () => {
+            const {data: {user}} = await supabaseClient.auth.getUser();
+            setUser(user ?? undefined);
+        };
+        fetchUser();
+    }, []);
+
+    useEffect(() => {
+        if (!id) return;
+        const fetchClimb = async () => {
+            const response = await fetch(`${BACKEND_URL}/climbs/${id}`);
+            const data = await response.json();
+            if (data.success) setClimb(data.data);
+        };
+        const fetchComments = async () => {
+            const response = await fetch(`${BACKEND_URL}/climbs/${id}/comments`);
+            const data = await response.json();
+            if (data.success) setComments(data.data);
+        };
+        setLoading(true);
+        Promise.all([fetchClimb(), fetchComments()]).finally(() => setLoading(false));
+    }, [id]);
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!id || !user || submitting) return;
+        const trimmed = body.trim();
+        if (!trimmed) return;
+        setSubmitting(true);
+        try {
+            const response = await fetch(`${BACKEND_URL}/climbs/${id}/comments`, {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({
+                    climb: Number(id),
+                    author: user.id,
+                    authorName: user.user_metadata?.name ?? user.email ?? null,
+                    authorAvatar: user.user_metadata?.avatar_url ?? null,
+                    body: trimmed,
+                }),
+            });
+            const data = await response.json();
+            if (data.success) {
+                setBody("");
+                const refreshed = await fetch(`${BACKEND_URL}/climbs/${id}/comments`);
+                const refreshedData = await refreshed.json();
+                if (refreshedData.success) setComments(refreshedData.data);
+                toast("Comment posted", {autoClose: 1500});
+            } else {
+                toast.error("Failed to post comment", {autoClose: 2500});
+            }
+        } catch {
+            toast.error("Failed to post comment", {autoClose: 2500});
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const formatTimestamp = (iso: string) => {
+        const date = new Date(iso);
+        return date.toLocaleString();
+    };
+
+    return (
+        <>
+            <div className={"climb-detail-page"}>
+                <button className={"climb-detail-back"} onClick={() => navigate(-1)}>← Back</button>
+                <ToastContainer className={"toast"}/>
+                {loading && !climb ? (
+                    <p>Loading...</p>
+                ) : climb ? (
+                    <div className={"climb-detail-header"}>
+                        <h1>{climb.name}</h1>
+                        <div className={"climb-detail-header-meta"}>
+                            <span>{climb.difficulty}</span>
+                            <span>•</span>
+                            <span>{climb.type}</span>
+                            <span>•</span>
+                            <span>{climb.gym}</span>
+                            <span
+                                className={"cooler-circle"}
+                                style={{backgroundColor: ROUTE_COLORS[climb.color] ?? "transparent"}}
+                                title={climb.color}
+                            />
+                        </div>
+                        <div>Set by {climb.setter}</div>
+                    </div>
+                ) : (
+                    <p>Climb not found.</p>
+                )}
+
+                <section className={"climb-comments"}>
+                    <h2>Comments</h2>
+
+                    <form className={"comment-form"} onSubmit={handleSubmit}>
+                        <textarea
+                            value={body}
+                            onChange={(event) => setBody(event.target.value.slice(0, MAX_LENGTH))}
+                            placeholder={user ? "Share beta or a note..." : "Sign in to comment"}
+                            disabled={!user || submitting}
+                            maxLength={MAX_LENGTH}
+                        />
+                        <div className={"comment-form-row"}>
+                            <span>{body.length}/{MAX_LENGTH}</span>
+                            <button type={"submit"} disabled={!user || submitting || !body.trim()}>
+                                {submitting ? "Posting..." : "Post comment"}
+                            </button>
+                        </div>
+                    </form>
+
+                    <div className={"comment-list"}>
+                        {comments.length === 0 ? (
+                            <p>No comments yet — be the first to share beta.</p>
+                        ) : (
+                            comments.map((comment) => (
+                                <div key={comment.id} className={"comment-item"}>
+                                    <div className={"comment-meta"}>
+                                        {comment.author_avatar ? (
+                                            <img
+                                                className={"comment-avatar"}
+                                                src={comment.author_avatar}
+                                                alt={comment.author_name ?? "user avatar"}
+                                            />
+                                        ) : null}
+                                        <strong>{comment.author_name ?? "Anonymous"}</strong>
+                                        <span>•</span>
+                                        <span>{formatTimestamp(comment.created_at)}</span>
+                                    </div>
+                                    <p className={"comment-body"}>{comment.body}</p>
+                                </div>
+                            ))
+                        )}
+                    </div>
+                </section>
+            </div>
+            <HomeRow/>
+        </>
+    );
+}

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import ClimbDetail from "./climbdetail.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -53,6 +54,14 @@ function Root() {
                 element={
                     <ProtectedRoute session={session}>
                         <Profile/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/climb/:id"
+                element={
+                    <ProtectedRoute session={session}>
+                        <ClimbDetail/>
                     </ProtectedRoute>
                 }
             />

--- a/frontend/src/pages/styles/climbdetail.css
+++ b/frontend/src/pages/styles/climbdetail.css
@@ -1,0 +1,142 @@
+.climb-detail-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 16px;
+    padding-bottom: 96px;
+    gap: 16px;
+}
+
+.climb-detail-header {
+    border: 3px solid black;
+    background-color: #EDCDB7;
+    border-radius: 16px;
+    padding: 12px 16px;
+    width: 90%;
+    max-width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.climb-detail-header h1 {
+    margin: 0;
+    font-size: 24px;
+}
+
+.climb-detail-header-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    font-size: 14px;
+}
+
+.climb-detail-header-meta .cooler-circle {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 1px solid black;
+}
+
+.climb-comments {
+    width: 90%;
+    max-width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.climb-comments h2 {
+    margin: 0;
+    font-size: 20px;
+}
+
+.comment-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.comment-item {
+    background-color: #ECEDED;
+    border: 2px solid black;
+    border-radius: 12px;
+    padding: 8px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.comment-meta {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: #333;
+}
+
+.comment-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.comment-body {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.comment-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.comment-form textarea {
+    width: 100%;
+    min-height: 80px;
+    padding: 8px;
+    border-radius: 8px;
+    border: 2px solid black;
+    background-color: white;
+    font-family: inherit;
+    resize: vertical;
+    box-sizing: border-box;
+}
+
+.comment-form-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: #555;
+}
+
+.comment-form button {
+    border: 2px solid black;
+    background-color: #EDCDB7;
+    border-radius: 8px;
+    padding: 6px 14px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.comment-form button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.climb-detail-back {
+    align-self: flex-start;
+    margin-left: 5%;
+    border: 2px solid black;
+    background-color: #ECEDED;
+    border-radius: 8px;
+    padding: 4px 12px;
+    cursor: pointer;
+    font-weight: bold;
+}

--- a/frontend/src/pages/styles/climbelement.css
+++ b/frontend/src/pages/styles/climbelement.css
@@ -81,3 +81,14 @@ p {
     padding: 8px 8px 0 8px;
     height: fit-content;
 }
+
+.climb-comments-link {
+    margin: 4px 8px 8px 8px;
+    background: none;
+    border: none;
+    padding: 0;
+    color: #3498db;
+    text-decoration: underline;
+    font-size: 12px;
+    cursor: pointer;
+}

--- a/migrations/0001_create_comments.sql
+++ b/migrations/0001_create_comments.sql
@@ -1,0 +1,25 @@
+create table if not exists comments (
+    id bigint generated always as identity primary key,
+    climb bigint not null references climbs(id) on delete cascade,
+    author uuid not null references auth.users(id) on delete cascade,
+    author_name text,
+    author_avatar text,
+    body text not null check (char_length(body) > 0 and char_length(body) <= 2000),
+    created_at timestamptz not null default now()
+);
+
+create index if not exists comments_climb_idx on comments(climb, created_at desc);
+
+alter table comments enable row level security;
+
+create policy "comments_select_all"
+    on comments for select
+    using (true);
+
+create policy "comments_insert_own"
+    on comments for insert
+    with check (auth.uid() = author);
+
+create policy "comments_delete_own"
+    on comments for delete
+    using (auth.uid() = author);


### PR DESCRIPTION
## Summary

Adds a lightweight comments feature so climbers can leave notes/beta on individual climbs.

### Database
- New `migrations/0001_create_comments.sql`: creates a `comments` table with `climb` FK → `climbs(id)` (cascade), `author` FK → `auth.users(id)`, `author_name`, `author_avatar`, `body` (1–2000 chars), and `created_at`. Indexed on `(climb, created_at desc)`. RLS enabled with policies: everyone can `select`, authenticated users can `insert` / `delete` their own rows.

### Backend (`backend/src/routes.ts`)
- `GET /climbs/:id` — fetch a single climb (needed so the detail page can deep-link / refresh).
- `GET /climbs/:id/comments` — returns comments for a climb, oldest first.
- `POST /climbs/:id/comments` — inserts a comment. Trims/validates body length and requires `author`.
- All new routes use the existing `packageResponse` pattern.

### Frontend
- New `Comment` / `NewComment` types in `src/lib/types.ts`.
- New `src/pages/climbdetail.tsx` route at `/climb/:id` (wired into `main.tsx` behind `ProtectedRoute`). Shows the climb header, a comment list, and a textarea composer that uses the current Supabase user's id/name/avatar when posting.
- `ClimbElement.tsx` gets a small "Comments" link that navigates to the detail page. Propagation is stopped so the existing click-to-select-for-log behavior on the home page is preserved.
- New `climbdetail.css` styled consistently with the existing CSS approach (no Tailwind classes elsewhere in the repo despite the dep being installed).

## Assumptions

- Comment author identity comes from the already-used `supabaseClient.auth.getUser()` flow; the server trusts the `author` uuid sent by the client, same as how `POST /climbs/log` trusts `user`. RLS in the migration is the real enforcement boundary once the backend is pointed at a user-scoped key.
- No pagination / editing / deleting UI — kept scope to "create + list", matching the rest of the product's simplicity.

## Migration / ops

- Run `migrations/0001_create_comments.sql` against Supabase before deploying the backend. No new env vars.

## Follow-ups / known caveats

- Both `backend/npm run build` and `frontend/npm run build` were already failing on `main` before this change (unrelated TS strictness issues across every existing handler, plus a stray `.` in `frontend/src/pages/styles/profile.css` that breaks `vite build`). This PR does not touch those. The new code compiles as cleanly as the surrounding code, introduces no new lint errors in files I touched, and works under `tsx watch` / `vite dev`.
- A comment edit/delete endpoint and UI would be a natural next step; the RLS policy already allows a user to delete their own row.

## Test plan
- [ ] Apply `migrations/0001_create_comments.sql` in Supabase.
- [ ] `backend: npm run dev` → `GET /climbs/1/comments` returns `{success: true, data: []}` on a fresh table.
- [ ] `frontend: npm run dev` → navigate home → click "Comments" on a climb → post a comment while signed in → comment appears in the list.
- [ ] Deep-link `/climb/:id` refresh works.
- [ ] Signed-out users see a disabled composer.