### PR TITLE
feat: achievements: gamified badges system

### DIFF
--- a/backend/src/achievements.ts
+++ b/backend/src/achievements.ts
@@ -1,0 +1,152 @@
+import type {SupabaseClient} from "@supabase/supabase-js";
+
+interface CompletedClimbRow {
+    id: number;
+    climber: string;
+    climb: number;
+    created_at: string;
+    climbs: {
+        difficulty: string | null;
+        type: string | null;
+        color: string | null;
+    } | null;
+}
+
+export type AchievementCode =
+    | "first_climb"
+    | "five_climbs"
+    | "ten_climbs"
+    | "fifty_climbs"
+    | "first_v5"
+    | "first_510"
+    | "ten_in_a_week"
+    | "send_streak_3"
+    | "color_collector"
+    | "rainbow";
+
+export function computeUnlockedCodes(completed: CompletedClimbRow[]): Set<AchievementCode> {
+    const unlocked = new Set<AchievementCode>();
+    const total = completed.length;
+
+    if (total >= 1) unlocked.add("first_climb");
+    if (total >= 5) unlocked.add("five_climbs");
+    if (total >= 10) unlocked.add("ten_climbs");
+    if (total >= 50) unlocked.add("fifty_climbs");
+
+    if (completed.some(c => isV5OrHarder(c.climbs?.difficulty ?? null))) {
+        unlocked.add("first_v5");
+    }
+    if (completed.some(c => is510OrHarder(c.climbs?.difficulty ?? null))) {
+        unlocked.add("first_510");
+    }
+
+    const logDays = completed
+        .map(c => toDayString(c.created_at))
+        .filter((d): d is string => d !== null);
+
+    if (hasWindowOfCount(logDays, 7, 10)) unlocked.add("ten_in_a_week");
+    if (hasConsecutiveDayStreak(logDays, 3)) unlocked.add("send_streak_3");
+
+    const colors = new Set(
+        completed.map(c => c.climbs?.color).filter((c): c is string => !!c),
+    );
+    if (colors.size >= 5) unlocked.add("color_collector");
+    if (colors.size >= 10) unlocked.add("rainbow");
+
+    return unlocked;
+}
+
+function isV5OrHarder(difficulty: string | null): boolean {
+    if (!difficulty) return false;
+    const match = /^V(\d+)/.exec(difficulty);
+    if (!match || match[1] === undefined) return false;
+    return parseInt(match[1], 10) >= 5;
+}
+
+function is510OrHarder(difficulty: string | null): boolean {
+    if (!difficulty) return false;
+    const match = /^5\.(\d+)/.exec(difficulty);
+    if (!match || match[1] === undefined) return false;
+    return parseInt(match[1], 10) >= 10;
+}
+
+function toDayString(iso: string | null | undefined): string | null {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return null;
+    return d.toISOString().slice(0, 10);
+}
+
+function hasWindowOfCount(days: string[], windowDays: number, minCount: number): boolean {
+    if (days.length < minCount) return false;
+    const sorted = [...days].map(d => Date.parse(d)).sort((a, b) => a - b);
+    const windowMs = (windowDays - 1) * 24 * 60 * 60 * 1000;
+    let left = 0;
+    for (let right = 0; right < sorted.length; right++) {
+        while (sorted[right]! - sorted[left]! > windowMs) left++;
+        if (right - left + 1 >= minCount) return true;
+    }
+    return false;
+}
+
+function hasConsecutiveDayStreak(days: string[], minStreak: number): boolean {
+    if (days.length < minStreak) return false;
+    const unique = Array.from(new Set(days)).sort();
+    const oneDay = 24 * 60 * 60 * 1000;
+    let streak = 1;
+    for (let i = 1; i < unique.length; i++) {
+        const prev = Date.parse(unique[i - 1]!);
+        const curr = Date.parse(unique[i]!);
+        if (curr - prev === oneDay) {
+            streak++;
+            if (streak >= minStreak) return true;
+        } else if (curr !== prev) {
+            streak = 1;
+        }
+    }
+    return false;
+}
+
+export async function evaluateAndPersistUnlocks(
+    supabase: SupabaseClient,
+    userId: string,
+): Promise<{newlyUnlocked: AchievementCode[]} | {error: Error}> {
+    const {data: climbs, error: climbsError} = await supabase
+        .from("completed_climbs")
+        .select("id, climber, climb, created_at, climbs:climb(difficulty, type, color)")
+        .eq("climber", userId);
+    if (climbsError) return {error: climbsError as unknown as Error};
+
+    const unlocked = computeUnlockedCodes((climbs ?? []) as unknown as CompletedClimbRow[]);
+    if (unlocked.size === 0) return {newlyUnlocked: []};
+
+    const {data: catalog, error: catalogError} = await supabase
+        .from("achievements")
+        .select("id, code")
+        .in("code", Array.from(unlocked));
+    if (catalogError) return {error: catalogError as unknown as Error};
+
+    const rows = (catalog ?? []).map(a => ({user_id: userId, achievement_id: a.id}));
+    if (rows.length === 0) return {newlyUnlocked: []};
+
+    const {data: existing, error: existingError} = await supabase
+        .from("user_achievements")
+        .select("achievement_id")
+        .eq("user_id", userId);
+    if (existingError) return {error: existingError as unknown as Error};
+
+    const existingIds = new Set((existing ?? []).map(r => r.achievement_id as number));
+    const toInsert = rows.filter(r => !existingIds.has(r.achievement_id));
+
+    if (toInsert.length > 0) {
+        const {error: insertError} = await supabase.from("user_achievements").insert(toInsert);
+        if (insertError) return {error: insertError as unknown as Error};
+    }
+
+    const codeById = new Map((catalog ?? []).map(a => [a.id as number, a.code as AchievementCode]));
+    const newlyUnlocked = toInsert
+        .map(r => codeById.get(r.achievement_id))
+        .filter((c): c is AchievementCode => c !== undefined);
+
+    return {newlyUnlocked};
+}

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -13,6 +13,7 @@ import {
     ROPE_GRADES,
     BOULDER_GRADES, type Log
 } from "../../frontend/src/lib/types.ts";
+import {evaluateAndPersistUnlocks} from "./achievements.js";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
 export function setupRoutes(server: FastifyInstance) {
@@ -68,6 +69,21 @@ export function setupRoutes(server: FastifyInstance) {
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
         res.status(code).send(reply);
+    });
+
+    server.get("/achievements", async (_req, res) => {
+        const {reply, code} = await packageResponse(() => handleAchievementCatalog());
+        return res.status(code).send(reply);
+    });
+
+    server.get("/achievements/:uuid", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleUserAchievements(req.params as { uuid?: string }));
+        return res.status(code).send(reply);
+    });
+
+    server.post("/achievements/evaluate", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleEvaluate(req.body as { user?: string }));
+        return res.status(code).send(reply);
     });
 
     async function handleFeaturedClimbs(): Promise<Task> {
@@ -212,6 +228,70 @@ export function setupRoutes(server: FastifyInstance) {
         }
     }
 
+    async function handleAchievementCatalog(): Promise<Process<any>> {
+        const {data, error} = await server.supabase
+            .from("achievements")
+            .select("*")
+            .order("sort_order", {ascending: true});
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleUserAchievements(params: { uuid?: string }): Promise<Process<any>> {
+        const {uuid} = params;
+        if (!uuid) {
+            return {success: false, error: new Error("Missing user uuid"), code: 400};
+        }
+
+        const evalResult = await evaluateAndPersistUnlocks(server.supabase, uuid);
+        if ("error" in evalResult) {
+            return {success: false, error: evalResult.error, code: 500};
+        }
+
+        const {data: catalog, error: catalogError} = await server.supabase
+            .from("achievements")
+            .select("*")
+            .order("sort_order", {ascending: true});
+        if (catalogError) {
+            return {success: false, error: catalogError, code: 500};
+        }
+
+        const {data: unlocks, error: unlocksError} = await server.supabase
+            .from("user_achievements")
+            .select("achievement_id, unlocked_at")
+            .eq("user_id", uuid);
+        if (unlocksError) {
+            return {success: false, error: unlocksError, code: 500};
+        }
+
+        const unlockedMap = new Map<number, string>();
+        for (const row of unlocks ?? []) {
+            unlockedMap.set(row.achievement_id as number, row.unlocked_at as string);
+        }
+
+        const merged = (catalog ?? []).map(a => ({
+            ...a,
+            unlocked: unlockedMap.has(a.id as number),
+            unlocked_at: unlockedMap.get(a.id as number) ?? null,
+        }));
+
+        return {success: true, data: merged};
+    }
+
+    async function handleEvaluate(body: { user?: string }): Promise<Process<any>> {
+        const userId = body?.user;
+        if (!userId) {
+            return {success: false, error: new Error("Missing user"), code: 400};
+        }
+        const result = await evaluateAndPersistUnlocks(server.supabase, userId);
+        if ("error" in result) {
+            return {success: false, error: result.error, code: 500};
+        }
+        return {success: true, data: result.newlyUnlocked};
+    }
+
     async function handleLog(req: Log): Promise<Task> {
         const {user, climb} = req;
         const {data, error} = await server.supabase.from("completed_climbs").insert([{
@@ -221,6 +301,7 @@ export function setupRoutes(server: FastifyInstance) {
         if (error) {
             return {success: false, error: error, code: 500};
         }
+        await evaluateAndPersistUnlocks(server.supabase, user);
         return {success: true, data: data};
     }
 

--- a/frontend/src/components/HomeRow.tsx
+++ b/frontend/src/components/HomeRow.tsx
@@ -22,6 +22,14 @@ export default function HomeRow() {
                 </svg>
                 <p>Add Climb</p>
             </div>
+            <div className={'achievements-button'} onClick={() => navigate("/achievements")}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
+                     className="bi bi-trophy" viewBox="0 0 16 16" >
+                    <path
+                        d="M2.5.5A.5.5 0 0 1 3 0h10a.5.5 0 0 1 .5.5q0 .807-.034 1.536a3 3 0 1 1-1.133 5.89c-.79 1.865-1.878 2.777-2.833 3.011v2.173l1.425.356c.194.048.377.135.537.255L13.3 15.1a.5.5 0 0 1-.3.9H3a.5.5 0 0 1-.3-.9l1.838-1.379c.16-.12.343-.207.537-.255L6.5 13.11v-2.173c-.955-.234-2.043-1.146-2.833-3.012a3 3 0 1 1-1.132-5.89A34 34 0 0 1 2.5.5m.099 2.54a2 2 0 0 0 .72 3.935c-.333-1.05-.588-2.346-.72-3.935m10.083 3.935a2 2 0 0 0 .72-3.935c-.133 1.59-.388 2.885-.72 3.935M3.504 1q.01.775.056 1.469c.13 2.028.457 3.546.87 4.667C5.294 9.48 6.484 10 7 10h2c.516 0 1.706-.52 2.57-2.864.413-1.12.74-2.64.87-4.667q.045-.694.056-1.469z"/>
+                </svg>
+                <p>Badges</p>
+            </div>
             <div className={'profile-button'} onClick={() => navigate("/profile")}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor"
                      className="bi bi-person" viewBox="0 0 16 16" >

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,20 @@ export interface Log {
     climb: number;
 }
 
+export interface Achievement {
+    id: number;
+    code: string;
+    name: string;
+    description: string;
+    icon: string;
+    sort_order: number;
+}
+
+export interface AchievementStatus extends Achievement {
+    unlocked: boolean;
+    unlocked_at: string | null;
+}
+
 export const BACKEND_URL: string = 'http://localhost:8000';
 export const FRONTEND_URL: string = 'http://localhost:5173';
 

--- a/frontend/src/pages/achievements.tsx
+++ b/frontend/src/pages/achievements.tsx
@@ -1,0 +1,101 @@
+import "./styles/achievements.css";
+import HomeRow from "../components/HomeRow.tsx";
+import {useEffect, useState} from "react";
+import type {User} from "@supabase/supabase-js";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import {type AchievementStatus, BACKEND_URL} from "../lib/types.ts";
+
+const ICONS: Record<string, string> = {
+    trophy: "\u{1F3C6}",
+    flame: "\u{1F525}",
+    medal: "\u{1F3C5}",
+    crown: "\u{1F451}",
+    boulder: "\u{1FAA8}",
+    rope: "\u{1F9D7}",
+    calendar: "\u{1F4C5}",
+    streak: "\u26A1",
+    palette: "\u{1F3A8}",
+    rainbow: "\u{1F308}",
+};
+
+export default function Achievements() {
+    const [user, setUser] = useState<User>();
+    const [badges, setBadges] = useState<AchievementStatus[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchUser = async () => {
+            const {data: {user}} = await supabaseClient.auth.getUser();
+            setUser(user ?? undefined);
+        };
+        fetchUser();
+    }, []);
+
+    useEffect(() => {
+        if (!user?.id) return;
+        const fetchBadges = async () => {
+            setLoading(true);
+            try {
+                const response = await fetch(`${BACKEND_URL}/achievements/${user.id}`);
+                const data = await response.json();
+                if (data.success) {
+                    setBadges(data.data as AchievementStatus[]);
+                } else {
+                    console.error("Failed to load achievements:", data.error);
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchBadges();
+    }, [user]);
+
+    const unlockedCount = badges.filter(b => b.unlocked).length;
+
+    const formatDate = (iso: string | null) => {
+        if (!iso) return null;
+        const d = new Date(iso);
+        if (isNaN(d.getTime())) return null;
+        return d.toLocaleDateString();
+    };
+
+    return (
+        <>
+            <div className={"achievements-page"}>
+                <div className={"heading"}>
+                    <h1>Achievements</h1>
+                    <p className={"progress"}>
+                        {badges.length > 0
+                            ? `${unlockedCount} of ${badges.length} unlocked`
+                            : loading
+                                ? "Loading..."
+                                : "No achievements available"}
+                    </p>
+                </div>
+
+                <div className={"badges-grid"}>
+                    {badges.map(badge => {
+                        const icon = ICONS[badge.icon] ?? "\u{1F3C5}";
+                        const unlockedDate = formatDate(badge.unlocked_at);
+                        return (
+                            <div
+                                key={badge.id}
+                                className={`badge ${badge.unlocked ? "unlocked" : "locked"}`}
+                            >
+                                <div className={"badge-icon"}>{icon}</div>
+                                <div className={"badge-body"}>
+                                    <p className={"badge-name"}>{badge.name}</p>
+                                    <p className={"badge-description"}>{badge.description}</p>
+                                    {badge.unlocked && unlockedDate && (
+                                        <p className={"badge-date"}>Unlocked {unlockedDate}</p>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+            <HomeRow/>
+        </>
+    );
+}

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import Achievements from "./achievements.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -53,6 +54,14 @@ function Root() {
                 element={
                     <ProtectedRoute session={session}>
                         <Profile/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/achievements"
+                element={
+                    <ProtectedRoute session={session}>
+                        <Achievements/>
                     </ProtectedRoute>
                 }
             />

--- a/frontend/src/pages/styles/achievements.css
+++ b/frontend/src/pages/styles/achievements.css
@@ -1,0 +1,119 @@
+.achievements-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding-bottom: 96px;
+}
+
+.achievements-page .heading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 24px;
+    margin-bottom: 16px;
+}
+
+.achievements-page .heading h1 {
+    display: flex;
+    border: 3px solid black;
+    background-color: #EDCDB7;
+    padding: 4px 16px;
+    width: fit-content;
+}
+
+.achievements-page .progress {
+    margin-top: 8px;
+    font-weight: 600;
+}
+
+.badges-grid {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
+    gap: 16px;
+    padding: 8px 16px;
+    width: 100%;
+    max-width: 1200px;
+    box-sizing: border-box;
+}
+
+@media only screen and (min-width: 600px) {
+    .badges-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media only screen and (min-width: 992px) {
+    .badges-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media only screen and (min-width: 1200px) {
+    .badges-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.badge {
+    border: 3px solid black;
+    background-color: #EDCDB7;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 12px;
+    gap: 12px;
+    position: relative;
+}
+
+.badge.locked {
+    background-color: #D7D7D7;
+    color: #555;
+    filter: grayscale(0.5);
+}
+
+.badge .badge-icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    border: 2px solid black;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #B7D7ED;
+    font-size: 28px;
+    flex-shrink: 0;
+}
+
+.badge.locked .badge-icon {
+    background-color: #C7C7C7;
+}
+
+.badge .badge-body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.badge .badge-name {
+    font-weight: 700;
+    font-size: 18px;
+    margin: 0;
+}
+
+.badge .badge-description {
+    font-size: 14px;
+    margin: 2px 0 0 0;
+}
+
+.badge .badge-date {
+    font-size: 12px;
+    margin-top: 4px;
+    opacity: 0.7;
+}
+
+.achievements-nav {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}

--- a/frontend/src/pages/styles/homerow.css
+++ b/frontend/src/pages/styles/homerow.css
@@ -17,7 +17,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-right: 10vw;
+    margin-right: 6vw;
 }
 
 .add-button {
@@ -26,11 +26,18 @@
     align-items: center;
 }
 
+.achievements-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 6vw;
+}
+
 .profile-button {
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-left: 10vw;
+    margin-left: 6vw;
 }
 
 .home-row p {
@@ -62,6 +69,10 @@
     }
 
     .add-button {
+        margin-left: 20px;
+    }
+
+    .achievements-button {
         margin-left: 20px;
     }
 

--- a/migrations/20260423_achievements.sql
+++ b/migrations/20260423_achievements.sql
@@ -1,0 +1,40 @@
+-- Achievements / badges system.
+-- Creates a catalog of achievements and a per-user unlock table.
+
+create table if not exists achievements (
+    id           serial primary key,
+    code         text not null unique,
+    name         text not null,
+    description  text not null,
+    icon         text not null,
+    sort_order   integer not null default 0
+);
+
+create table if not exists user_achievements (
+    id             bigserial primary key,
+    user_id        uuid not null,
+    achievement_id integer not null references achievements(id) on delete cascade,
+    unlocked_at    timestamptz not null default now(),
+    unique (user_id, achievement_id)
+);
+
+create index if not exists user_achievements_user_id_idx on user_achievements(user_id);
+
+-- Seed the initial achievement catalog. The backend evaluates these by code,
+-- so the codes are the stable identifier and must not change.
+insert into achievements (code, name, description, icon, sort_order) values
+    ('first_climb',       'First Ascent',     'Log your very first climb.',                              'trophy',   10),
+    ('five_climbs',       'Getting Warm',     'Log 5 climbs.',                                           'flame',    20),
+    ('ten_climbs',        'Regular',          'Log 10 climbs.',                                          'medal',    30),
+    ('fifty_climbs',      'Gym Rat',          'Log 50 climbs.',                                          'crown',    40),
+    ('first_v5',          'First V5',         'Send your first V5 boulder.',                             'boulder',  50),
+    ('first_510',         'Breaking Into 10', 'Send your first 5.10 rope.',                              'rope',     60),
+    ('ten_in_a_week',     'Crusher Week',     'Log 10 climbs within a single rolling 7-day window.',     'calendar', 70),
+    ('send_streak_3',     'Send Streak',      'Log at least one climb on 3 different days in a row.',    'streak',   80),
+    ('color_collector',   'Color Collector',  'Send climbs in at least 5 different route colors.',       'palette',  90),
+    ('rainbow',           'Rainbow',          'Send climbs in at least 10 different route colors.',      'rainbow', 100)
+on conflict (code) do update
+    set name        = excluded.name,
+        description = excluded.description,
+        icon        = excluded.icon,
+        sort_order  = excluded.sort_order;


### PR DESCRIPTION
## Summary

Adds a gamified achievements / badges system end-to-end:

- **Database** (migration only, not run): `achievements` catalog table and `user_achievements` unlock table, seeded with 10 starter badges including *First Ascent*, *First V5*, *Breaking Into 10*, *Getting Warm / Regular / Gym Rat* (5/10/50 climbs), *Crusher Week* (10 climbs in a rolling 7-day window), *Send Streak* (3 consecutive days), and *Color Collector / Rainbow* (5 / 10 distinct route colors).
- **Backend** (`backend/src/achievements.ts`, `backend/src/routes.ts`):
  - `GET /achievements` — return the achievement catalog
  - `GET /achievements/:uuid` — evaluate a user's completed climbs, persist any newly unlocked badges, and return the full catalog annotated with `unlocked` / `unlocked_at`
  - `POST /achievements/evaluate` — force-re-evaluation (returns newly unlocked codes)
  - `POST /climbs/log` now also runs evaluation after a climb is logged so unlocks appear automatically.
- **Frontend**: new `/achievements` protected route with a responsive badges grid showing icon + name + description + unlock date (or a grayscaled locked state). Added a trophy button to the bottom `HomeRow` nav so users can reach the page from anywhere.

## Why

The existing app lets users log climbs but gives no feedback on progress. Badges are a low-risk, self-contained way to add retention/engagement without changing core flows — nothing here blocks or mutates existing climb/log behavior.

## Design notes & assumptions

- Achievement *criteria* live in code (`computeUnlockedCodes` in `backend/src/achievements.ts`), keyed by the stable `code` column. The DB row is only metadata (name, description, icon, sort order). This keeps criteria versioned in git and avoids a per-achievement rules table.
- Time-based criteria use `completed_climbs.created_at` (when logged), not `climbs.date_set`, so they reflect the climber's own activity cadence.
- *First V5* / *Breaking Into 10* parse `difficulty` with simple regex (`/^V(\d+)/`, `/^5\.(\d+)/`) — good enough for the seeded grade strings in `ROPE_GRADES` / `BOULDER_GRADES`.
- Unlocks are additive — a row in `user_achievements` with a unique `(user_id, achievement_id)` constraint. Evaluation is idempotent.
- Icons are rendered with emoji in the frontend (`ICONS` map), keyed by the `icon` column. Easy to swap for real SVG later.

## Follow-ups

1. **Run the migration**: `migrations/20260423_achievements.sql` is included but not executed. Apply via Supabase SQL editor / CLI.
2. Consider RLS policies for `user_achievements` — currently it relies on the backend's service-role key, matching the existing pattern for `completed_climbs`.
3. Add unit tests for `computeUnlockedCodes` once a test harness exists (repo currently has no tests).
4. Pre-existing TypeScript/lint errors in `routes.ts`, `home.tsx`, `FilterClimbs.tsx` etc. are untouched — this PR only matches the existing patterns and does not introduce new categories of errors.

## Test plan

- [ ] Apply `migrations/20260423_achievements.sql` to the Supabase project
- [ ] `cd backend && npm run dev`; `cd frontend && npm run dev`
- [ ] Log in, log a climb, confirm *First Ascent* appears unlocked on `/achievements`
- [ ] Log a V5+ boulder, confirm *First V5* unlocks
- [ ] Verify badge grid is responsive on mobile/desktop and locked badges render grayscaled