### PR TITLE
feat: add free-form tagging system for climbs

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -4,32 +4,32 @@
 import type {FastifyInstance} from "fastify";
 import {
     type BaseReply,
-    type Failure,
     type ReplyConfig,
-    type Task,
     type Process,
     type Climb,
     type Search,
     ROPE_GRADES,
-    BOULDER_GRADES, type Log
-} from "../../frontend/src/lib/types.ts";
+    BOULDER_GRADES, type Log,
+    type ClimbTagMutation
+} from "../../frontend/src/lib/types.js";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
 export function setupRoutes(server: FastifyInstance) {
     server.get<{
-        Reply: any[] | { error: string };
+        Reply: BaseReply<any>;
     }>("/featured", async (req, res) => {
         const {reply: result, code} = await packageResponse(() => handleFeaturedClimbs());
         return res.status(code).send(result);
     });
     server.get<{
-        Reply: any[] | { error: string };
+        Params: { uuid?: string };
+        Reply: BaseReply<any>;
     }>("/climbs/logged/:uuid", async (req, res) => {
         const {reply: result, code} = await packageResponse(() => handleLoggedClimbs(req.params));
         return res.status(code).send(result);
     });
     server.get<{
-        Reply: any[] | { error: string };
+        Reply: BaseReply<any>;
     }>("/climbs", async (req, res) => {
         const {reply: result, code} = await packageResponse(() => handleGetClimbs());
         return res.status(code).send(result);
@@ -37,14 +37,16 @@ export function setupRoutes(server: FastifyInstance) {
 
     server.post<{
         Body: Climb;
-        Reply: BaseReply<void>;
+        Reply: BaseReply<any>;
 
     }>("/climbs/new", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleNewClimb(req.body));
         res.status(code).send(reply);
     });
 
-    server.patch('/climbs/archive/:id', async (req, res) => {
+    server.patch<{
+        Params: { id?: string };
+    }>('/climbs/archive/:id', async (req, res) => {
         const {reply, code} = await packageResponse(() => handleArchive(req.params));
         res.status(code).send(reply);
 
@@ -52,7 +54,7 @@ export function setupRoutes(server: FastifyInstance) {
 
     server.post<{
         Body: Search;
-        Reply: BaseReply<void>;
+        Reply: BaseReply<any>;
     }>("/climbs/search/filter", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleFilteredSearch(req.body));
         res.status(code).send(reply);
@@ -64,13 +66,44 @@ export function setupRoutes(server: FastifyInstance) {
             user: string,
             climb: number
         };
-        Reply: BaseReply<void>;
+        Reply: BaseReply<any>;
     }>("/climbs/log", async (req, res) => {
         const {reply, code} = await packageResponse(() => handleLog(req.body));
         res.status(code).send(reply);
     });
 
-    async function handleFeaturedClimbs(): Promise<Task> {
+    server.get<{
+        Reply: BaseReply<any>;
+    }>("/tags", async (_req, res) => {
+        const {reply, code} = await packageResponse(() => handleListTags());
+        return res.status(code).send(reply);
+    });
+
+    server.get<{
+        Params: { id?: string };
+        Reply: BaseReply<any>;
+    }>("/climbs/:id/tags", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleGetClimbTags(req.params));
+        return res.status(code).send(reply);
+    });
+
+    server.post<{
+        Body: ClimbTagMutation;
+        Reply: BaseReply<any>;
+    }>("/climbs/tags/add", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleAddTag(req.body));
+        res.status(code).send(reply);
+    });
+
+    server.post<{
+        Body: ClimbTagMutation;
+        Reply: BaseReply<any>;
+    }>("/climbs/tags/remove", async (req, res) => {
+        const {reply, code} = await packageResponse(() => handleRemoveTag(req.body));
+        res.status(code).send(reply);
+    });
+
+    async function handleFeaturedClimbs(): Promise<Process<unknown>> {
         const twoWeeksAgo = new Date();
         twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
         const query = server.supabase.from("climbs")
@@ -83,7 +116,7 @@ export function setupRoutes(server: FastifyInstance) {
 
     }
 
-    async function handleGetClimbs(): Promise<Task> {
+    async function handleGetClimbs(): Promise<Process<unknown>> {
         const query = server.supabase.from("climbs").select("*");
         const {data, error} = await query;
         if (error) {
@@ -94,7 +127,7 @@ export function setupRoutes(server: FastifyInstance) {
     }
 
 //TODO: Handle pictures
-    async function handleNewClimb(req: Climb): Promise<Task> {
+    async function handleNewClimb(req: Climb): Promise<Process<unknown>> {
         const {name, difficulty, type, color, setter, dateSet, gym} = req;
         const {data, error} = await server.supabase.from("climbs").insert([
             {
@@ -113,7 +146,7 @@ export function setupRoutes(server: FastifyInstance) {
         return {success: true, data: data};
     }
 
-    async function handleArchive(params: { id?: string }): Promise<Task> {
+    async function handleArchive(params: { id?: string }): Promise<Process<unknown>> {
         const {id} = params;
         const {data, error} = await server.supabase.from("climbs").update({archived: true}).eq("id", id).select();
         if (error) {
@@ -123,7 +156,7 @@ export function setupRoutes(server: FastifyInstance) {
 
     }
 
-    async function handleLoggedClimbs(params: { uuid?: string }): Promise<Task> {
+    async function handleLoggedClimbs(params: { uuid?: string }): Promise<Process<unknown>> {
         const {uuid} = params;
         const {data, error} = await server.supabase.from("completed_climbs").select(`
             *,
@@ -135,9 +168,38 @@ export function setupRoutes(server: FastifyInstance) {
     }
 
 //TODO: remove for loop
-    async function handleFilteredSearch(req: Search): Promise<Task> {
-        const {lowerDifficulty, upperDifficulty, type, color, startDate, endDate, gym, archived} = req;
+    async function handleFilteredSearch(req: Search): Promise<Process<unknown>> {
+        const {lowerDifficulty, upperDifficulty, type, color, startDate, endDate, gym, archived, tags} = req;
         const query = server.supabase.from("climbs").select('*');
+
+        if (tags && tags.length > 0) {
+            const cleanTags = tags.map(normalizeTagName).filter(Boolean);
+            if (cleanTags.length > 0) {
+                const {data: matchedTags, error: tagErr} = await server.supabase
+                    .from("tags")
+                    .select("id,name")
+                    .or(cleanTags.map(t => `name.ilike.${t}`).join(","));
+                if (tagErr) {
+                    return {success: false, error: tagErr, code: 500};
+                }
+                const tagIds = (matchedTags ?? []).map((t: any) => t.id);
+                if (tagIds.length === 0) {
+                    return {success: true, data: []};
+                }
+                const {data: links, error: linkErr} = await server.supabase
+                    .from("climb_tags")
+                    .select("climb")
+                    .in("tag", tagIds);
+                if (linkErr) {
+                    return {success: false, error: linkErr, code: 500};
+                }
+                const climbIds = Array.from(new Set((links ?? []).map((l: any) => l.climb)));
+                if (climbIds.length === 0) {
+                    return {success: true, data: []};
+                }
+                query.in("id", climbIds);
+            }
+        }
         let boulderList: string[] = Object.keys(BOULDER_GRADES);
         let ropeList: string[] = Object.keys(ROPE_GRADES);
         const filter: Record<string, any> = {
@@ -196,23 +258,123 @@ export function setupRoutes(server: FastifyInstance) {
         return {success: true, data: data};
     }
 
-    function sortByGrade(type: string, bound: string, filterGrade: string, gradeList: string[]) {
-        if (type === "Top Rope") {
-            if (bound === "lower") {
-                return gradeList.filter(grade => ROPE_GRADES[grade] >= ROPE_GRADES[filterGrade]);
-            } else if (bound === "upper") {
-                return gradeList.filter(grade => ROPE_GRADES[grade] <= ROPE_GRADES[filterGrade]);
-            }
-        } else if (type === "Boulder") {
-            if (bound === "lower") {
-                return gradeList.filter(grade => BOULDER_GRADES[grade] >= BOULDER_GRADES[filterGrade]);
-            } else if (bound === "upper") {
-                return gradeList.filter(grade => BOULDER_GRADES[grade] <= BOULDER_GRADES[filterGrade]);
-            }
+    function sortByGrade(type: string, bound: string, filterGrade: string, gradeList: string[]): string[] {
+        const table = type === "Top Rope" ? ROPE_GRADES : type === "Boulder" ? BOULDER_GRADES : null;
+        if (!table) return gradeList;
+        const threshold = table[filterGrade];
+        if (threshold === undefined) return gradeList;
+        if (bound === "lower") {
+            return gradeList.filter(grade => (table[grade] ?? -Infinity) >= threshold);
         }
+        if (bound === "upper") {
+            return gradeList.filter(grade => (table[grade] ?? Infinity) <= threshold);
+        }
+        return gradeList;
     }
 
-    async function handleLog(req: Log): Promise<Task> {
+    function normalizeTagName(raw: string): string {
+        return raw.trim().replace(/\s+/g, " ");
+    }
+
+    async function handleListTags(): Promise<Process<unknown>> {
+        const {data, error} = await server.supabase.from("tags").select("id,name").order("name", {ascending: true});
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: data};
+    }
+
+    async function handleGetClimbTags(params: { id?: string }): Promise<Process<unknown>> {
+        const {id} = params;
+        if (!id) {
+            return {success: false, error: new Error("Missing climb id"), code: 400};
+        }
+        const {data, error} = await server.supabase
+            .from("climb_tags")
+            .select("tags:tag(id,name)")
+            .eq("climb", id);
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        const tags = (data ?? []).map((row: any) => row.tags).filter(Boolean);
+        return {success: true, data: tags};
+    }
+
+    async function upsertTagByName(name: string): Promise<{ id: number; name: string } | { error: Error }> {
+        const clean = normalizeTagName(name);
+        if (!clean) {
+            return {error: new Error("Tag name cannot be empty")};
+        }
+        const existing = await server.supabase
+            .from("tags")
+            .select("id,name")
+            .ilike("name", clean)
+            .maybeSingle();
+        if (existing.error) {
+            return {error: existing.error};
+        }
+        if (existing.data) {
+            return {id: existing.data.id, name: existing.data.name};
+        }
+        const inserted = await server.supabase
+            .from("tags")
+            .insert([{name: clean}])
+            .select("id,name")
+            .single();
+        if (inserted.error) {
+            return {error: inserted.error};
+        }
+        return {id: inserted.data.id, name: inserted.data.name};
+    }
+
+    async function handleAddTag(req: ClimbTagMutation): Promise<Process<unknown>> {
+        const {climb, tag} = req;
+        if (climb === undefined || climb === null || !tag) {
+            return {success: false, error: new Error("climb and tag are required"), code: 400};
+        }
+        const resolved = await upsertTagByName(tag);
+        if ("error" in resolved) {
+            return {success: false, error: resolved.error, code: 500};
+        }
+        const {data, error} = await server.supabase
+            .from("climb_tags")
+            .upsert([{climb: climb, tag: resolved.id}], {onConflict: "climb,tag"})
+            .select();
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: {climb, tag: resolved, rows: data}};
+    }
+
+    async function handleRemoveTag(req: ClimbTagMutation): Promise<Process<unknown>> {
+        const {climb, tag} = req;
+        if (climb === undefined || climb === null || !tag) {
+            return {success: false, error: new Error("climb and tag are required"), code: 400};
+        }
+        const clean = normalizeTagName(tag);
+        const lookup = await server.supabase
+            .from("tags")
+            .select("id")
+            .ilike("name", clean)
+            .maybeSingle();
+        if (lookup.error) {
+            return {success: false, error: lookup.error, code: 500};
+        }
+        if (!lookup.data) {
+            return {success: true, data: {removed: 0}};
+        }
+        const {error} = await server.supabase
+            .from("climb_tags")
+            .delete()
+            .eq("climb", climb)
+            .eq("tag", lookup.data.id);
+        if (error) {
+            return {success: false, error: error, code: 500};
+        }
+        return {success: true, data: {removed: 1}};
+    }
+
+    async function handleLog(req: Log): Promise<Process<unknown>> {
         const {user, climb} = req;
         const {data, error} = await server.supabase.from("completed_climbs").insert([{
             climber: user,

--- a/frontend/src/components/ClimbElement.tsx
+++ b/frontend/src/components/ClimbElement.tsx
@@ -1,6 +1,6 @@
 import {type Climb, ROUTE_COLORS} from "../lib/types.ts";
 import '../pages/styles/climbelement.css'
-import {useState} from "react";
+import TagChips from "./TagChips.tsx";
 
 interface ClimbElementProps {
     jsonClimb: Climb;
@@ -54,6 +54,9 @@ export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: Cl
             <h1>{difficulty}</h1>
             <div className={'cooler-circle'} style={{backgroundColor: ROUTE_COLORS[color]}}></div>
             <h4>{formatLocalHeader(dateSet)}</h4>
+        </div>
+        <div className={"climb-tags-row"}>
+            <TagChips climbId={climbId}/>
         </div>
     </div>);
 

--- a/frontend/src/components/FilterClimbs.tsx
+++ b/frontend/src/components/FilterClimbs.tsx
@@ -1,6 +1,7 @@
 import {BOULDER_GRADES, ROPE_GRADES, ROUTE_COLORS, type Search} from "../lib/types.ts";
 import {useEffect, useState} from "react";
 import '../pages/styles/filterclimbs.css'
+import '../pages/styles/tagchips.css'
 
 export default function FilterClimbs({filter, onAdvSearch}) {
     const [type, setType] = useState("Any");
@@ -10,6 +11,23 @@ export default function FilterClimbs({filter, onAdvSearch}) {
     const [archived, setArchived] = useState<boolean>(false);
     const [startDate, setStartDate] = useState("");
     const [endDate, setEndDate] = useState("");
+    const [tags, setTags] = useState<string[]>([]);
+    const [tagDraft, setTagDraft] = useState("");
+
+    const addTagToFilter = () => {
+        const name = tagDraft.trim();
+        if (!name) return;
+        if (tags.some(t => t.toLowerCase() === name.toLowerCase())) {
+            setTagDraft("");
+            return;
+        }
+        setTags([...tags, name]);
+        setTagDraft("");
+    };
+
+    const removeTagFromFilter = (name: string) => {
+        setTags(tags.filter(t => t !== name));
+    };
 
     const advancedSearch = (formData: FormData) => {
         const newFilter: Search = {
@@ -21,8 +39,9 @@ export default function FilterClimbs({filter, onAdvSearch}) {
             endDate: formData.get('endDate') as Date,
             gym: formData.get('gym') as string,
             archived: formData.get('archived') as boolean,
+            tags: tags.length > 0 ? tags : undefined,
         }
-        if (newFilter.archived === null && newFilter.color === "Any" && newFilter.gym === "Any" && newFilter.type === "Any" && newFilter.startDate === "" && newFilter.endDate === "") {
+        if (newFilter.archived === null && newFilter.color === "Any" && newFilter.gym === "Any" && newFilter.type === "Any" && newFilter.startDate === "" && newFilter.endDate === "" && (!newFilter.tags || newFilter.tags.length === 0)) {
             onAdvSearch(undefined);
             return;
         }
@@ -106,6 +125,35 @@ export default function FilterClimbs({filter, onAdvSearch}) {
                 </label>
 
 
+                <label className={'tags-filter'}>
+                    <p>Tags</p>
+                    <div className={'tag-filter-chips'}>
+                        {tags.map(t => (
+                            <span key={t} className={'tag-filter-chip'}>
+                                {t}
+                                <button type={'button'} aria-label={`Remove ${t}`}
+                                        onClick={() => removeTagFromFilter(t)}>×</button>
+                            </span>
+                        ))}
+                    </div>
+                    <div className={'tag-filter-input-wrap'}>
+                        <input
+                            type={'text'}
+                            value={tagDraft}
+                            onChange={e => setTagDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                    e.preventDefault();
+                                    addTagToFilter();
+                                }
+                            }}
+                            placeholder={'e.g. crimpy'}
+                            maxLength={40}
+                        />
+                        <button type={'button'} onClick={addTagToFilter}>Add</button>
+                    </div>
+                </label>
+
                 <label className={'archived-climbs'}>
                     <p>Include Archived Climbs</p>
                     <input name={'archived'} type={"checkbox"} checked={archived}
@@ -128,6 +176,8 @@ export default function FilterClimbs({filter, onAdvSearch}) {
                         setEndDate("");
                         setGym("Any");
                         setArchived(false);
+                        setTags([]);
+                        setTagDraft("");
                         onAdvSearch(undefined);
                     }}>Clear Filters
                     </button>

--- a/frontend/src/components/TagChips.tsx
+++ b/frontend/src/components/TagChips.tsx
@@ -1,0 +1,158 @@
+import {useEffect, useState} from "react";
+import {BACKEND_URL, type Tag} from "../lib/types.ts";
+import "../pages/styles/tagchips.css";
+
+interface TagChipsProps {
+    climbId: number;
+    initialTags?: Tag[];
+    editable?: boolean;
+    onTagsChange?: (tags: Tag[]) => void;
+}
+
+export default function TagChips({climbId, initialTags, editable = true, onTagsChange}: TagChipsProps) {
+    const [tags, setTags] = useState<Tag[]>(initialTags ?? []);
+    const [loaded, setLoaded] = useState<boolean>(initialTags !== undefined);
+    const [adding, setAdding] = useState(false);
+    const [draft, setDraft] = useState("");
+    const [busy, setBusy] = useState(false);
+
+    useEffect(() => {
+        if (loaded) return;
+        let cancelled = false;
+        const load = async () => {
+            try {
+                const res = await fetch(`${BACKEND_URL}/climbs/${climbId}/tags`);
+                const payload = await res.json();
+                if (cancelled) return;
+                if (payload.success) {
+                    setTags(payload.data ?? []);
+                }
+            } catch (err) {
+                console.error("Failed to load tags", err);
+            } finally {
+                if (!cancelled) setLoaded(true);
+            }
+        };
+        load();
+        return () => {
+            cancelled = true;
+        };
+    }, [climbId, loaded]);
+
+    const publish = (next: Tag[]) => {
+        setTags(next);
+        onTagsChange?.(next);
+    };
+
+    const addTag = async (raw: string) => {
+        const name = raw.trim();
+        if (!name) return;
+        if (tags.some(t => t.name.toLowerCase() === name.toLowerCase())) {
+            setDraft("");
+            setAdding(false);
+            return;
+        }
+        setBusy(true);
+        try {
+            const res = await fetch(`${BACKEND_URL}/climbs/tags/add`, {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({climb: climbId, tag: name}),
+            });
+            const payload = await res.json();
+            if (payload.success && payload.data?.tag) {
+                publish([...tags, {id: payload.data.tag.id, name: payload.data.tag.name}]);
+            }
+        } catch (err) {
+            console.error("Failed to add tag", err);
+        } finally {
+            setBusy(false);
+            setDraft("");
+            setAdding(false);
+        }
+    };
+
+    const removeTag = async (tag: Tag) => {
+        setBusy(true);
+        try {
+            const res = await fetch(`${BACKEND_URL}/climbs/tags/remove`, {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({climb: climbId, tag: tag.name}),
+            });
+            const payload = await res.json();
+            if (payload.success) {
+                publish(tags.filter(t => t.id !== tag.id));
+            }
+        } catch (err) {
+            console.error("Failed to remove tag", err);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+
+    return (
+        <div className={"tag-chips"} onClick={stop}>
+            {tags.map(tag => (
+                <span key={tag.id} className={"tag-chip"}>
+                    <span className={"tag-chip-label"}>{tag.name}</span>
+                    {editable && (
+                        <button
+                            type={"button"}
+                            className={"tag-chip-remove"}
+                            aria-label={`Remove ${tag.name}`}
+                            disabled={busy}
+                            onClick={(e) => {
+                                stop(e);
+                                removeTag(tag);
+                            }}
+                        >
+                            ×
+                        </button>
+                    )}
+                </span>
+            ))}
+            {editable && (adding ? (
+                <form
+                    className={"tag-chip-form"}
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        addTag(draft);
+                    }}
+                >
+                    <input
+                        autoFocus
+                        className={"tag-chip-input"}
+                        type={"text"}
+                        value={draft}
+                        disabled={busy}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onBlur={() => {
+                            if (draft.trim()) {
+                                addTag(draft);
+                            } else {
+                                setAdding(false);
+                            }
+                        }}
+                        placeholder={"e.g. crimpy"}
+                        maxLength={40}
+                    />
+                </form>
+            ) : (
+                <button
+                    type={"button"}
+                    className={"tag-chip-add"}
+                    disabled={busy}
+                    onClick={(e) => {
+                        stop(e);
+                        setAdding(true);
+                    }}
+                >
+                    + tag
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -21,11 +21,22 @@ export interface Search {
     endDate: Date;
     gym: string;
     archived: boolean;
+    tags?: string[];
 }
 
 export interface Log {
     user: string;
     climb: number;
+}
+
+export interface Tag {
+    id: number;
+    name: string;
+}
+
+export interface ClimbTagMutation {
+    climb: number;
+    tag: string;
 }
 
 export const BACKEND_URL: string = 'http://localhost:8000';

--- a/frontend/src/pages/styles/climbelement.css
+++ b/frontend/src/pages/styles/climbelement.css
@@ -14,12 +14,19 @@
 
 .climb-container {
     display: flex;
+    flex-wrap: wrap;
     border-radius: 16px;
     width: 280px;
     margin: 8px;
     background-color: #ECEDED;
     border: 2px solid black;
 
+}
+
+.climb-tags-row {
+    flex: 1 0 100%;
+    border-top: 1px solid #cfd2d6;
+    padding: 2px 4px 4px;
 }
 
 .climb-container.highlighted {

--- a/frontend/src/pages/styles/tagchips.css
+++ b/frontend/src/pages/styles/tagchips.css
@@ -1,0 +1,120 @@
+.tag-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 4px 6px;
+    align-items: center;
+}
+
+.tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background-color: #e4ebf3;
+    color: #1f2a44;
+    border: 1px solid #b7c4d4;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 12px;
+    line-height: 1.4;
+    max-width: 100%;
+}
+
+.tag-chip-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 120px;
+}
+
+.tag-chip-remove {
+    background: none;
+    border: none;
+    color: #1f2a44;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    padding: 0;
+    margin: 0;
+}
+
+.tag-chip-remove:disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+
+.tag-chip-add {
+    border: 1px dashed #8a9cb2;
+    background: transparent;
+    color: #1f2a44;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.tag-chip-add:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.tag-chip-form {
+    display: inline-flex;
+}
+
+.tag-chip-input {
+    border: 1px solid #b7c4d4;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 12px;
+    outline: none;
+    width: 100px;
+}
+
+.tag-filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+}
+
+.tag-filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background-color: #e4ebf3;
+    color: #1f2a44;
+    border: 1px solid #b7c4d4;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 12px;
+}
+
+.tag-filter-chip button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    padding: 0;
+}
+
+.tag-filter-input-wrap {
+    display: flex;
+    gap: 4px;
+}
+
+.tag-filter-input-wrap input {
+    border: 1px solid #b7c4d4;
+    border-radius: 6px;
+    padding: 2px 6px;
+    font-size: 12px;
+}
+
+.tag-filter-input-wrap button {
+    border: 1px solid #b7c4d4;
+    background: #f5f7fa;
+    border-radius: 6px;
+    padding: 2px 8px;
+    cursor: pointer;
+    font-size: 12px;
+}

--- a/migrations/0001_climb_tags.sql
+++ b/migrations/0001_climb_tags.sql
@@ -1,0 +1,21 @@
+-- Free-form tagging system for climbs.
+-- Tags are stored once in `tags` (case-insensitive unique name) and joined
+-- to climbs via `climb_tags`.
+
+create table if not exists tags (
+    id bigserial primary key,
+    name text not null,
+    created_at timestamptz not null default now()
+);
+
+create unique index if not exists tags_name_lower_idx on tags (lower(name));
+
+create table if not exists climb_tags (
+    climb bigint not null references climbs(id) on delete cascade,
+    tag bigint not null references tags(id) on delete cascade,
+    created_at timestamptz not null default now(),
+    primary key (climb, tag)
+);
+
+create index if not exists climb_tags_tag_idx on climb_tags (tag);
+create index if not exists climb_tags_climb_idx on climb_tags (climb);


### PR DESCRIPTION
## Summary
- New `tags` and `climb_tags` tables (see `migrations/0001_climb_tags.sql`) let each climb carry any number of free-form labels (e.g. `crimpy`, `slabby`, `comp style`). Tag names are stored once and compared case-insensitively.
- Backend exposes `GET /tags`, `GET /climbs/:id/tags`, `POST /climbs/tags/add`, and `POST /climbs/tags/remove`. The add route upserts the tag by name, so clients never have to manage tag IDs.
- Frontend renders tag chips inline on each climb card (new `TagChips` component) with `+`/`×` affordances, and `FilterClimbs` grew a Tags section where users stack chip filters. `Search` now accepts an optional `tags: string[]` that the backend intersects into the filter query.

## Why
The existing climb filtering is grid-style (grade, color, gym, date) and leaves no room for the style-based descriptors that climbers naturally talk about. Tags give climbers (and setters) a fast, low-ceremony vocabulary for *what the climb feels like*, and they plug directly into the existing filter UI.

## Assumptions
- **No auth scoping.** Tags are global and any authenticated user (the frontend already sits behind `ProtectedRoute`) can add or remove tags. If you want tags to be per-user or setter-only, we can add an `author` column and a policy in a follow-up.
- **Case-insensitive dedupe.** `tags.name` uses a `lower(name)` unique index, and the backend compares with `ilike`. `Crimpy`, `crimpy`, and `CRIMPY` all resolve to one tag.
- **Soft remove semantics.** `POST /climbs/tags/remove` 200s with `{removed: 0}` when the tag doesn't exist — no error, just a no-op, to keep the UI simple.
- **Name normalization.** Input is trimmed and internal whitespace is collapsed to single spaces; max length in the UI is 40 chars, but there's no DB-level cap.

## Follow-ups / operator notes
- **Run the migration.** `migrations/0001_climb_tags.sql` is included but not executed. Apply it against the Supabase project before deploying (via the SQL editor or `supabase db push`).
- **No env var changes** required for this PR.
- **Pre-existing TypeScript errors remain on the frontend build.** This PR does not fix them — they exist on `main` today in files this PR doesn't meaningfully change (`home.tsx`, `main.tsx`, `newclimb.tsx`, `SearchBar.tsx`, `profile.tsx`). The touched files (`TagChips.tsx`, `FilterClimbs.tsx`, `ClimbElement.tsx`, `types.ts`) don't add new TS or lint errors. The backend build is now clean — a few small tidy-ups in `routes.ts` were needed to get there (widened handler return types, filled in `Params` generics, tightened `sortByGrade`). Those are listed in the commit body.
- Potential follow-ups: tag autocomplete from `GET /tags`, usage counts, color coding by tag, and moderation (rename/merge) tooling.

## Test plan
- [ ] Apply `migrations/0001_climb_tags.sql` on a Supabase dev project.
- [ ] `curl -X POST $BACKEND/climbs/tags/add -d '{"climb":<id>,"tag":"crimpy"}'` and confirm `GET /climbs/<id>/tags` returns it.
- [ ] Add the same tag twice and confirm it dedupes (no duplicate row in `climb_tags`).
- [ ] From the UI, add a tag to a climb card, reload, and see it persist.
- [ ] Remove a tag via the × button; reload; confirm it's gone.
- [ ] In the filter panel, add `crimpy` as a tag filter and confirm only tagged climbs return.
- [ ] Clear Filters resets the tag chips along with the other filters.