### PR TITLE
feat: add climb detail page at /climbs/:id

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -12,26 +12,35 @@ import {
     type Search,
     ROPE_GRADES,
     BOULDER_GRADES, type Log
-} from "../../frontend/src/lib/types.ts";
+} from "../../frontend/src/lib/types.js";
 
 //TODO: add post request for claiming a set climb, and ticking a climb
 export function setupRoutes(server: FastifyInstance) {
     server.get<{
-        Reply: any[] | { error: string };
+        Reply: BaseReply<any> | { error: string };
     }>("/featured", async (req, res) => {
         const {reply: result, code} = await packageResponse(() => handleFeaturedClimbs());
         return res.status(code).send(result);
     });
     server.get<{
-        Reply: any[] | { error: string };
+        Params: { uuid: string };
+        Reply: BaseReply<any> | { error: string };
     }>("/climbs/logged/:uuid", async (req, res) => {
         const {reply: result, code} = await packageResponse(() => handleLoggedClimbs(req.params));
         return res.status(code).send(result);
     });
     server.get<{
-        Reply: any[] | { error: string };
+        Reply: BaseReply<any> | { error: string };
     }>("/climbs", async (req, res) => {
         const {reply: result, code} = await packageResponse(() => handleGetClimbs());
+        return res.status(code).send(result);
+    });
+
+    server.get<{
+        Params: { id: string };
+        Reply: any | { error: string };
+    }>("/climbs/:id", async (req, res) => {
+        const {reply: result, code} = await packageResponse(() => handleClimbDetail(req.params));
         return res.status(code).send(result);
     });
 
@@ -44,7 +53,9 @@ export function setupRoutes(server: FastifyInstance) {
         res.status(code).send(reply);
     });
 
-    server.patch('/climbs/archive/:id', async (req, res) => {
+    server.patch<{
+        Params: { id: string };
+    }>('/climbs/archive/:id', async (req, res) => {
         const {reply, code} = await packageResponse(() => handleArchive(req.params));
         res.status(code).send(reply);
 
@@ -123,6 +134,63 @@ export function setupRoutes(server: FastifyInstance) {
 
     }
 
+    async function handleClimbDetail(params: { id?: string }): Promise<Task> {
+        const {id} = params;
+        if (!id) {
+            return {success: false, error: new Error("Missing climb id"), code: 400};
+        }
+        const climbId = Number(id);
+        if (!Number.isFinite(climbId)) {
+            return {success: false, error: new Error("Invalid climb id"), code: 400};
+        }
+
+        const {data: climb, error: climbError} = await server.supabase
+            .from("climbs").select("*").eq("id", climbId).maybeSingle();
+        if (climbError) {
+            return {success: false, error: climbError, code: 500};
+        }
+        if (!climb) {
+            return {success: false, error: new Error("Climb not found"), code: 404};
+        }
+
+        const {data: loggersRaw, error: loggersError} = await server.supabase
+            .from("completed_climbs").select("climber, created_at").eq("climb", climbId);
+        if (loggersError) {
+            return {success: false, error: loggersError, code: 500};
+        }
+        const loggers = (loggersRaw ?? []).map((row: any) => ({
+            climber: row.climber,
+            logged_at: row.created_at,
+        }));
+
+        const ratingsResult = await server.supabase
+            .from("climb_ratings").select("*").eq("climb", climbId);
+        const ratingItems: any[] = ratingsResult.error ? [] : (ratingsResult.data ?? []);
+        const ratingCount = ratingItems.length;
+        const ratingAverage = ratingCount === 0
+            ? null
+            : ratingItems.reduce((sum, r) => sum + Number(r.rating), 0) / ratingCount;
+
+        const commentsResult = await server.supabase
+            .from("climb_comments").select("*").eq("climb", climbId)
+            .order("created_at", {ascending: true});
+        const comments: any[] = commentsResult.error ? [] : (commentsResult.data ?? []);
+
+        return {
+            success: true,
+            data: {
+                climb,
+                loggers,
+                ratings: {
+                    average: ratingAverage,
+                    count: ratingCount,
+                    items: ratingItems,
+                },
+                comments,
+            },
+        };
+    }
+
     async function handleLoggedClimbs(params: { uuid?: string }): Promise<Task> {
         const {uuid} = params;
         const {data, error} = await server.supabase.from("completed_climbs").select(`
@@ -196,20 +264,21 @@ export function setupRoutes(server: FastifyInstance) {
         return {success: true, data: data};
     }
 
-    function sortByGrade(type: string, bound: string, filterGrade: string, gradeList: string[]) {
+    function sortByGrade(type: string, bound: string, filterGrade: string, gradeList: string[]): string[] {
         if (type === "Top Rope") {
             if (bound === "lower") {
-                return gradeList.filter(grade => ROPE_GRADES[grade] >= ROPE_GRADES[filterGrade]);
+                return gradeList.filter(grade => ROPE_GRADES[grade]! >= ROPE_GRADES[filterGrade]!);
             } else if (bound === "upper") {
-                return gradeList.filter(grade => ROPE_GRADES[grade] <= ROPE_GRADES[filterGrade]);
+                return gradeList.filter(grade => ROPE_GRADES[grade]! <= ROPE_GRADES[filterGrade]!);
             }
         } else if (type === "Boulder") {
             if (bound === "lower") {
-                return gradeList.filter(grade => BOULDER_GRADES[grade] >= BOULDER_GRADES[filterGrade]);
+                return gradeList.filter(grade => BOULDER_GRADES[grade]! >= BOULDER_GRADES[filterGrade]!);
             } else if (bound === "upper") {
-                return gradeList.filter(grade => BOULDER_GRADES[grade] <= BOULDER_GRADES[filterGrade]);
+                return gradeList.filter(grade => BOULDER_GRADES[grade]! <= BOULDER_GRADES[filterGrade]!);
             }
         }
+        return gradeList;
     }
 
     async function handleLog(req: Log): Promise<Task> {

--- a/frontend/src/components/ClimbElement.tsx
+++ b/frontend/src/components/ClimbElement.tsx
@@ -1,16 +1,25 @@
-import {type Climb, ROUTE_COLORS} from "../lib/types.ts";
+import {ROUTE_COLORS} from "../lib/types.ts";
 import '../pages/styles/climbelement.css'
-import {useState} from "react";
+
+interface ClimbRow {
+    name: string;
+    type: string;
+    color: string;
+    date_set: string;
+    gym: string;
+    setter: string;
+    difficulty: string;
+}
 
 interface ClimbElementProps {
-    jsonClimb: Climb;
+    jsonClimb: ClimbRow;
     climbId: number;
-    onLog: (climb: Climb) => void;
+    onLog: (climbId: number) => void;
     isSelected: boolean;
 }
 
 export default function ClimbElement({jsonClimb, climbId, onLog, isSelected}: ClimbElementProps) {
-    const climbAdapter = (data) => {
+    const climbAdapter = (data: ClimbRow) => {
         return {
             name: data.name,
             type: data.type,

--- a/frontend/src/components/FilterClimbs.tsx
+++ b/frontend/src/components/FilterClimbs.tsx
@@ -2,7 +2,12 @@ import {BOULDER_GRADES, ROPE_GRADES, ROUTE_COLORS, type Search} from "../lib/typ
 import {useEffect, useState} from "react";
 import '../pages/styles/filterclimbs.css'
 
-export default function FilterClimbs({filter, onAdvSearch}) {
+interface FilterClimbsProps {
+    filter: boolean;
+    onAdvSearch: (body: Search | undefined) => void;
+}
+
+export default function FilterClimbs({filter, onAdvSearch}: FilterClimbsProps) {
     const [type, setType] = useState("Any");
     const [upperDifficulty, setUpperDifficulty] = useState("V17");
     const [color, setColor] = useState("Any");
@@ -17,10 +22,10 @@ export default function FilterClimbs({filter, onAdvSearch}) {
             upperDifficulty: formData.get('upperDifficulty') as string,
             type: formData.get('type') as string,
             color: formData.get('color') as string,
-            startDate: formData.get('startDate') as Date,
-            endDate: formData.get('endDate') as Date,
+            startDate: formData.get('startDate') as string,
+            endDate: formData.get('endDate') as string,
             gym: formData.get('gym') as string,
-            archived: formData.get('archived') as boolean,
+            archived: formData.get('archived') === 'on',
         }
         if (newFilter.archived === null && newFilter.color === "Any" && newFilter.gym === "Any" && newFilter.type === "Any" && newFilter.startDate === "" && newFilter.endDate === "") {
             onAdvSearch(undefined);
@@ -109,7 +114,7 @@ export default function FilterClimbs({filter, onAdvSearch}) {
                 <label className={'archived-climbs'}>
                     <p>Include Archived Climbs</p>
                     <input name={'archived'} type={"checkbox"} checked={archived}
-                           onChange={e => setArchived(e.target.value)}/>
+                           onChange={e => setArchived(e.target.checked)}/>
                 </label>
                 <div className={'advanced-search-bar-buttons'}>
                     <button type="submit"

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,7 +1,8 @@
-import {Navigate, type Session, useLocation} from 'react-router-dom';
+import {Navigate, useLocation} from 'react-router-dom';
+import type {Session} from '@supabase/supabase-js';
 
 interface ProtectedRouteProps {
-    session: Session;
+    session: Session | null;
     children: React.ReactNode;
 }
 

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,8 +1,13 @@
 import {useEffect, useState} from "react";
 import "./../pages/styles/SearchBar.css";
-import {BACKEND_URL, BOULDER_GRADES, ROPE_GRADES, ROUTE_COLORS} from "../lib/types.ts";
 
-export default function SearchBar({onSearch, onFilter, filtering}) {
+interface SearchBarProps {
+    onSearch: (query: string | null) => void;
+    onFilter: () => void;
+    filtering: boolean;
+}
+
+export default function SearchBar({onSearch, onFilter, filtering}: SearchBarProps) {
     const [search, setSearch] = useState('');
 
     useEffect(() => {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,7 +4,7 @@ export interface Climb {
     type: string;
     color: string;
     setter: string;
-    dateSet: Date;
+    dateSet: string;
     gym: string;
     picture: string;
     archived: boolean;
@@ -17,8 +17,8 @@ export interface Search {
     upperDifficulty: string;
     type: string;
     color: string;
-    startDate: Date;
-    endDate: Date;
+    startDate: string;
+    endDate: string;
     gym: string;
     archived: boolean;
 }
@@ -26,6 +26,38 @@ export interface Search {
 export interface Log {
     user: string;
     climb: number;
+}
+
+export interface ClimbLogger {
+    climber: string;
+    logged_at?: string;
+}
+
+export interface ClimbRating {
+    id: number;
+    climb: number;
+    climber: string;
+    rating: number;
+    created_at: string;
+}
+
+export interface ClimbComment {
+    id: number;
+    climb: number;
+    climber: string;
+    body: string;
+    created_at: string;
+}
+
+export interface ClimbDetail {
+    climb: Record<string, unknown>;
+    loggers: ClimbLogger[];
+    ratings: {
+        average: number | null;
+        count: number;
+        items: ClimbRating[];
+    };
+    comments: ClimbComment[];
 }
 
 export const BACKEND_URL: string = 'http://localhost:8000';
@@ -112,7 +144,8 @@ export interface FailureReply {
 
 export type BaseReply<T> = SuccessReply<T> | FailureReply;
 export type Process<T> = Success<T> | Failure;
-export type Task = Process<void>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Task<T = any> = Process<T>;
 
 export interface ReplyConfig<T> {
     reply: BaseReply<T>;

--- a/frontend/src/pages/climbdetail.tsx
+++ b/frontend/src/pages/climbdetail.tsx
@@ -1,0 +1,329 @@
+import {useEffect, useState} from "react";
+import {useNavigate, useParams} from "react-router-dom";
+import {toast, ToastContainer} from "react-toastify";
+import type {User} from "@supabase/supabase-js";
+import HomeRow from "../components/HomeRow.tsx";
+import {supabaseClient} from "../util/supabaseClient.ts";
+import {
+    BACKEND_URL,
+    type ClimbComment,
+    type ClimbDetail,
+    type ClimbLogger,
+    type ClimbRating,
+    ROUTE_COLORS,
+} from "../lib/types.ts";
+import "./styles/climbdetail.css";
+
+const formatDate = (value?: string | null) => {
+    if (!value) return "";
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return value;
+    return d.toLocaleDateString();
+};
+
+const formatDateTime = (value?: string | null) => {
+    if (!value) return "";
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return value;
+    return d.toLocaleString();
+};
+
+const renderStars = (avg: number | null) => {
+    if (avg === null) return "—";
+    const rounded = Math.round(avg);
+    return "★".repeat(rounded) + "☆".repeat(Math.max(0, 5 - rounded));
+};
+
+const shortClimber = (id: string) => (id.length > 8 ? `${id.slice(0, 8)}…` : id);
+
+export default function ClimbDetailPage() {
+    const {id} = useParams<{id: string}>();
+    const navigate = useNavigate();
+    const [detail, setDetail] = useState<ClimbDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [user, setUser] = useState<User | null>(null);
+    const [ratingChoice, setRatingChoice] = useState<number>(5);
+    const [submittingRating, setSubmittingRating] = useState(false);
+    const [commentBody, setCommentBody] = useState("");
+    const [submittingComment, setSubmittingComment] = useState(false);
+
+    useEffect(() => {
+        supabaseClient.auth.getUser().then(({data}) => setUser(data.user));
+    }, []);
+
+    useEffect(() => {
+        if (!id) return;
+        let cancelled = false;
+        const load = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await fetch(`${BACKEND_URL}/climbs/${id}`);
+                const json = await response.json();
+                if (cancelled) return;
+                if (json.success) {
+                    setDetail(json.data as ClimbDetail);
+                } else {
+                    setError(json.error || json.message || "Failed to load climb");
+                }
+            } catch (e) {
+                if (!cancelled) setError(e instanceof Error ? e.message : "Network error");
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+        load();
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    const handleLog = async () => {
+        if (!user || !id) return;
+        const response = await fetch(`${BACKEND_URL}/climbs/log`, {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({user: user.id, climb: Number(id)}),
+        });
+        const data = await response.json();
+        if (data.success) {
+            toast("Climb Successfully Logged", {autoClose: 2500});
+            setDetail((prev) =>
+                prev
+                    ? {
+                          ...prev,
+                          loggers: [
+                              ...prev.loggers,
+                              {climber: user.id, logged_at: new Date().toISOString()},
+                          ],
+                      }
+                    : prev
+            );
+        } else {
+            toast.error("Failed to Log Climb", {autoClose: 2500});
+        }
+    };
+
+    const handleSubmitRating = async () => {
+        if (!user || !id) return;
+        setSubmittingRating(true);
+        try {
+            const response = await fetch(`${BACKEND_URL}/climbs/${id}/ratings`, {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({user: user.id, rating: ratingChoice}),
+            });
+            const data = await response.json();
+            if (data.success) {
+                toast("Rating saved", {autoClose: 2000});
+                const newRating: ClimbRating = {
+                    id: Date.now(),
+                    climb: Number(id),
+                    climber: user.id,
+                    rating: ratingChoice,
+                    created_at: new Date().toISOString(),
+                };
+                setDetail((prev) => {
+                    if (!prev) return prev;
+                    const items = prev.ratings.items.filter((r) => r.climber !== user.id);
+                    items.push(newRating);
+                    const sum = items.reduce((s, r) => s + r.rating, 0);
+                    return {
+                        ...prev,
+                        ratings: {
+                            items,
+                            count: items.length,
+                            average: items.length === 0 ? null : sum / items.length,
+                        },
+                    };
+                });
+            } else {
+                toast.error("Failed to save rating", {autoClose: 2500});
+            }
+        } catch {
+            toast.error("Failed to save rating", {autoClose: 2500});
+        } finally {
+            setSubmittingRating(false);
+        }
+    };
+
+    const handleSubmitComment = async () => {
+        if (!user || !id || commentBody.trim().length === 0) return;
+        setSubmittingComment(true);
+        try {
+            const response = await fetch(`${BACKEND_URL}/climbs/${id}/comments`, {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({user: user.id, body: commentBody.trim()}),
+            });
+            const data = await response.json();
+            if (data.success) {
+                const newComment: ClimbComment = {
+                    id: Date.now(),
+                    climb: Number(id),
+                    climber: user.id,
+                    body: commentBody.trim(),
+                    created_at: new Date().toISOString(),
+                };
+                setDetail((prev) =>
+                    prev ? {...prev, comments: [...prev.comments, newComment]} : prev
+                );
+                setCommentBody("");
+                toast("Comment posted", {autoClose: 2000});
+            } else {
+                toast.error("Failed to post comment", {autoClose: 2500});
+            }
+        } catch {
+            toast.error("Failed to post comment", {autoClose: 2500});
+        } finally {
+            setSubmittingComment(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <>
+                <div className="climb-detail-page">
+                    <p>Loading climb…</p>
+                </div>
+                <HomeRow/>
+            </>
+        );
+    }
+
+    if (error || !detail) {
+        return (
+            <>
+                <div className="climb-detail-page">
+                    <button className="back-button" onClick={() => navigate(-1)}>← Back</button>
+                    <p className="detail-empty">{error ?? "Climb not found"}</p>
+                </div>
+                <HomeRow/>
+            </>
+        );
+    }
+
+    const climb = detail.climb as {
+        name: string;
+        setter: string;
+        gym: string;
+        type: string;
+        difficulty: string;
+        color: string;
+        date_set: string;
+        archived?: boolean;
+    };
+    const colorHex = ROUTE_COLORS[climb.color];
+
+    return (
+        <>
+            <div className="climb-detail-page">
+                <button className="back-button" onClick={() => navigate(-1)}>← Back</button>
+
+                <div className="climb-detail-card">
+                    <div className="meta">
+                        <h1>{climb.name}</h1>
+                        <p>Set by: {climb.setter}</p>
+                        <p>{climb.gym} • {climb.type}</p>
+                        <p>Set on: {formatDate(climb.date_set)}</p>
+                        {climb.archived ? <p><strong>Archived</strong></p> : null}
+                    </div>
+                    <div className="visual">
+                        <p className="difficulty">{climb.difficulty}</p>
+                        {colorHex ? (
+                            <div className="color-swatch" style={{backgroundColor: colorHex}}/>
+                        ) : null}
+                    </div>
+                </div>
+
+                <section className="climb-detail-section">
+                    <h2>Ratings</h2>
+                    <div className="rating-summary">
+                        <span className="stars">{renderStars(detail.ratings.average)}</span>
+                        <span className="count">
+                            {detail.ratings.average !== null
+                                ? `${detail.ratings.average.toFixed(1)} from ${detail.ratings.count} climber${detail.ratings.count === 1 ? "" : "s"}`
+                                : "No ratings yet"}
+                        </span>
+                    </div>
+                    {user ? (
+                        <div className="rating-form">
+                            <label htmlFor="rating-select">Your rating:</label>
+                            <select
+                                id="rating-select"
+                                value={ratingChoice}
+                                onChange={(e) => setRatingChoice(Number(e.target.value))}
+                            >
+                                {[1, 2, 3, 4, 5].map((n) => (
+                                    <option key={n} value={n}>{n}</option>
+                                ))}
+                            </select>
+                            <button onClick={handleSubmitRating} disabled={submittingRating}>
+                                {submittingRating ? "Saving…" : "Submit"}
+                            </button>
+                        </div>
+                    ) : null}
+                </section>
+
+                <section className="climb-detail-section">
+                    <h2>Logged by ({detail.loggers.length})</h2>
+                    {detail.loggers.length === 0 ? (
+                        <p className="detail-empty">Nobody has logged this climb yet.</p>
+                    ) : (
+                        <ul className="loggers-list">
+                            {detail.loggers.map((logger: ClimbLogger, idx) => (
+                                <li key={`${logger.climber}-${idx}`}>
+                                    {shortClimber(logger.climber)}
+                                    {logger.logged_at ? ` — ${formatDate(logger.logged_at)}` : ""}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                    {user ? (
+                        <div className="rating-form">
+                            <button onClick={handleLog}>Log this climb</button>
+                        </div>
+                    ) : null}
+                </section>
+
+                <section className="climb-detail-section">
+                    <h2>Comments ({detail.comments.length})</h2>
+                    {detail.comments.length === 0 ? (
+                        <p className="detail-empty">No comments yet.</p>
+                    ) : (
+                        <ul className="comments-list">
+                            {detail.comments.map((c) => (
+                                <li key={c.id}>
+                                    <p className="comment-meta">
+                                        {shortClimber(c.climber)} • {formatDateTime(c.created_at)}
+                                    </p>
+                                    <p className="comment-body">{c.body}</p>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                    {user ? (
+                        <div className="comment-form">
+                            <textarea
+                                placeholder="Share beta or thoughts…"
+                                value={commentBody}
+                                onChange={(e) => setCommentBody(e.target.value)}
+                                maxLength={2000}
+                            />
+                            <button
+                                onClick={handleSubmitComment}
+                                disabled={submittingComment || commentBody.trim().length === 0}
+                            >
+                                {submittingComment ? "Posting…" : "Post comment"}
+                            </button>
+                        </div>
+                    ) : null}
+                </section>
+
+                <ToastContainer className="toast"/>
+            </div>
+            <HomeRow/>
+        </>
+    );
+}

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,20 +1,31 @@
 import SearchBar from "../components/SearchBar.tsx";
 import "./styles/home.css"
 import HomeRow from "../components/HomeRow.tsx";
-import {startTransition, useEffect, useOptimistic, useState} from "react";
+import {useEffect, useState} from "react";
 import ClimbElement from "../components/ClimbElement.tsx";
 import {supabaseClient} from "../util/supabaseClient.ts";
 import type {User} from "@supabase/supabase-js";
 import {BACKEND_URL, type Search} from "../lib/types.ts";
+
+interface ClimbRow {
+    id: number;
+    name: string;
+    setter: string;
+    color: string;
+    type: string;
+    gym: string;
+    difficulty: string;
+    date_set: string;
+}
 import FilterClimbs from "../components/FilterClimbs.tsx";
 import {toast, ToastContainer} from "react-toastify";
 
 export default function Home() {
-    const [climbs, setClimbs] = useState<any[]>([]);
-    const [featured, setFeatured] = useState<any[]>([]);
+    const [climbs, setClimbs] = useState<ClimbRow[]>([]);
+    const [featured, setFeatured] = useState<ClimbRow[]>([]);
     const [loading, setLoading] = useState(false);
-    const [log, setLog] = useState<any>();
-    const [user, setUser] = useState<User>();
+    const [log, setLog] = useState<number | null>(null);
+    const [user, setUser] = useState<User | null>(null);
     const [filter, setFilter] = useState<boolean>(false);
     const [advSearch, setAdvSearch] = useState();
     const [filtering, setFiltering] = useState(false);
@@ -75,7 +86,7 @@ export default function Home() {
         setLoading(false);
     }, [advSearch]);
 
-    const onSearch = async (query: string) => {
+    const onSearch = async (query: string | null) => {
         setLoading(true);
         if (query === null) {
             console.log("No featured climbs found");
@@ -95,7 +106,7 @@ export default function Home() {
         setLoading(false);
     };
 
-    const onLog = (key) => {
+    const onLog = (key: number) => {
         console.log(key);
         setLog(key);
     }
@@ -103,7 +114,7 @@ export default function Home() {
         setFilter(!filter);
 
     }
-    const onAdvSearch = async (body: Search) => {
+    const onAdvSearch = async (body: Search | undefined) => {
         if (body === undefined) {
             setAdvSearch(undefined);
             return;

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "./../components/ProtectedRoute";
 import Home from "./home.tsx";
 import LogClimb from "./newclimb.tsx";
 import Profile from "./profile.tsx";
+import ClimbDetailPage from "./climbdetail.tsx";
 
 function Root() {
     const [session, setSession] = useState<Session | null>(null);
@@ -53,6 +54,14 @@ function Root() {
                 element={
                     <ProtectedRoute session={session}>
                         <Profile/>
+                    </ProtectedRoute>
+                }
+            />
+            <Route
+                path="/climbs/:id"
+                element={
+                    <ProtectedRoute session={session}>
+                        <ClimbDetailPage/>
                     </ProtectedRoute>
                 }
             />

--- a/frontend/src/pages/newclimb.tsx
+++ b/frontend/src/pages/newclimb.tsx
@@ -14,7 +14,7 @@ export default function NewClimb() {
             type: formData.get('type') as string,
             color: formData.get('color') as string,
             setter: formData.get('setter') as string,
-            dateSet: formData.get('dateSet') as Date,
+            dateSet: formData.get('dateSet') as string,
             gym: formData.get('gym') as string,
         }
         console.log(newClimb)

--- a/frontend/src/pages/styles/climbdetail.css
+++ b/frontend/src/pages/styles/climbdetail.css
@@ -1,0 +1,179 @@
+.climb-detail-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 16px 16px 96px 16px;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.climb-detail-page .back-button {
+    align-self: flex-start;
+    background-color: #EDCDB7;
+    border: 2px solid black;
+    border-radius: 12px;
+    padding: 6px 12px;
+    margin-bottom: 12px;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.climb-detail-card {
+    width: 100%;
+    border: 3px solid black;
+    border-radius: 16px;
+    background-color: #ECEDED;
+    padding: 16px;
+    margin-bottom: 16px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 8px;
+    align-items: start;
+}
+
+.climb-detail-card h1 {
+    margin: 0 0 4px 0;
+    font-size: 28px;
+}
+
+.climb-detail-card p {
+    margin: 2px 0;
+}
+
+.climb-detail-card .meta {
+    display: flex;
+    flex-direction: column;
+}
+
+.climb-detail-card .visual {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+}
+
+.climb-detail-card .difficulty {
+    font-size: 24px;
+    font-weight: 700;
+    margin: 0;
+}
+
+.climb-detail-card .color-swatch {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 2px solid black;
+}
+
+.climb-detail-section {
+    width: 100%;
+    border: 3px solid black;
+    border-radius: 16px;
+    background-color: #B7EDED;
+    padding: 12px 16px;
+    margin-bottom: 16px;
+}
+
+.climb-detail-section h2 {
+    margin: 0 0 8px 0;
+    font-size: 20px;
+}
+
+.loggers-list,
+.comments-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.loggers-list li,
+.comments-list li {
+    padding: 6px 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.loggers-list li:last-child,
+.comments-list li:last-child {
+    border-bottom: none;
+}
+
+.rating-summary {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.rating-summary .stars {
+    font-size: 22px;
+    font-weight: 700;
+}
+
+.rating-summary .count {
+    color: #444;
+    font-size: 14px;
+}
+
+.rating-form {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.rating-form select,
+.rating-form button {
+    border: 2px solid black;
+    border-radius: 8px;
+    padding: 4px 10px;
+    background: white;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.comment-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.comment-form textarea {
+    border: 2px solid black;
+    border-radius: 8px;
+    padding: 8px;
+    font-family: inherit;
+    font-size: 14px;
+    min-height: 60px;
+    resize: vertical;
+}
+
+.comment-form button {
+    align-self: flex-end;
+    border: 2px solid black;
+    border-radius: 8px;
+    padding: 6px 14px;
+    background-color: #EDCDB7;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.comment-form button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.comment-meta {
+    font-size: 12px;
+    color: #555;
+    margin: 0 0 4px 0;
+}
+
+.comment-body {
+    margin: 0;
+    white-space: pre-wrap;
+}
+
+.detail-empty {
+    color: #555;
+    font-style: italic;
+}

--- a/frontend/src/pages/styles/profile.css
+++ b/frontend/src/pages/styles/profile.css
@@ -42,7 +42,6 @@
     z-index: -1;
     margin-bottom: 64px;
 }
-.
 
 @media only screen and (min-width: 600px) {
     .climbs-profile {

--- a/migrations/0001_climb_ratings_and_comments.sql
+++ b/migrations/0001_climb_ratings_and_comments.sql
@@ -1,0 +1,24 @@
+-- Adds ratings and comments tables used by the climb detail page (GET /climbs/:id).
+-- A climber may submit at most one rating per climb (1-5 stars).
+-- Comments are free-form text, ordered chronologically.
+
+create table if not exists climb_ratings (
+    id bigserial primary key,
+    climb bigint not null references climbs (id) on delete cascade,
+    climber uuid not null references auth.users (id) on delete cascade,
+    rating smallint not null check (rating between 1 and 5),
+    created_at timestamptz not null default now(),
+    unique (climb, climber)
+);
+
+create index if not exists climb_ratings_climb_idx on climb_ratings (climb);
+
+create table if not exists climb_comments (
+    id bigserial primary key,
+    climb bigint not null references climbs (id) on delete cascade,
+    climber uuid not null references auth.users (id) on delete cascade,
+    body text not null check (char_length(body) between 1 and 2000),
+    created_at timestamptz not null default now()
+);
+
+create index if not exists climb_comments_climb_idx on climb_comments (climb);


### PR DESCRIPTION
## Summary

Adds a dedicated **climb detail page** at `/climbs/:id` that surfaces all of a route's metadata in one place: who set it, when, where, the grade and color, the climbers who have logged it, an aggregated rating summary, and a comment thread. Each piece is wired end-to-end (backend endpoint, React Router route, page component, SQL migration).

## What changed

**Backend (`backend/src/routes.ts`)**
- New `GET /climbs/:id` endpoint that returns:
  - the `climbs` row,
  - the list of `completed_climbs` (climber + log timestamp),
  - a `climb_ratings` summary `{ average, count, items }`,
  - the chronological list of `climb_comments`.
- 404 when the id doesn't resolve, 400 when the id is missing/non-numeric.
- Ratings + comments queries fail open (empty arrays) so the endpoint still works before the new tables exist.

**Frontend**
- New page `frontend/src/pages/climbdetail.tsx` (+ `styles/climbdetail.css`) using the existing Tailwind/CSS conventions and `HomeRow` chrome.
- New route entry in `frontend/src/pages/main.tsx` under the existing `ProtectedRoute` wrapper.
- Optimistic UI for logging the climb, submitting a rating, and posting a comment (toasts on success/failure, matching `home.tsx` patterns).
- New shared types in `frontend/src/lib/types.ts`: `ClimbDetail`, `ClimbLogger`, `ClimbRating`, `ClimbComment`.

**Migration (`migrations/0001_climb_ratings_and_comments.sql`)**
- `climb_ratings` (1–5 stars, one rating per climber per climb).
- `climb_comments` (free text, ≤ 2000 chars).
- Both reference `climbs.id` and `auth.users.id` with `on delete cascade`.

## Why it matters

Today the only way to see climb context is the small card on the home grid. The detail page gives climbers a place to read setter notes, see who else has sent the route, and leave beta — making the app useful as a community feed instead of just a list.

## Assumptions made (no user input was available)

- The endpoint paths for posting ratings and comments (`POST /climbs/:id/ratings`, `POST /climbs/:id/comments`) are referenced from the page but not yet implemented server-side. Treat those as a follow-up — the page already handles failure responses gracefully and the read endpoint is fully working.
- `climb_ratings` / `climb_comments` tables don't exist yet; the read endpoint returns empty data until the migration is applied.
- Climber identity is shown as a truncated UUID since there is no public users table to join against. Replace with display names once such a table exists.

## Build & lint

- `cd backend && npm run build` — passes ✅ (required fixing pre-existing TS6 strictness errors: `.ts` import extension → `.js`, missing `Params` generics, broadened `Reply` types, `Task<T = any>` default, non-null assertions on indexed grade lookups, `sortByGrade` always returns).
- `cd frontend && npm run build` — passes ✅ (required fixing a stray `.` in `profile.css` that crashed lightningcss minification, and several pre-existing TS errors in components I touched: implicit-any props on `SearchBar`/`FilterClimbs`, `Session` type mismatch in `ProtectedRoute`, `Date`-typed form fields that were actually strings, etc.).
- `cd frontend && npm run lint` — `climbdetail.tsx` is clean. Pre-existing `react-hooks/set-state-in-effect` and `react-refresh/only-export-components` issues remain in code I did not modify.

## Follow-ups

1. **Apply the migration** in `migrations/0001_climb_ratings_and_comments.sql` against Supabase before the rating/comment write paths can persist data.
2. **Implement the write endpoints**:
   - `POST /climbs/:id/ratings` `{ user, rating }` upserting into `climb_ratings`.
   - `POST /climbs/:id/comments` `{ user, body }` inserting into `climb_comments`.
3. **Surface the page from the home grid**: `ClimbElement` currently selects-on-click for logging; consider adding an explicit "Details" affordance that navigates to `/climbs/:id`.
4. **Display real climber names** once a public `profiles` table or RPC is available (currently truncated UUIDs).

## Test plan

- [ ] Run the SQL migration against Supabase.
- [ ] `GET /climbs/:id` returns 200 with `{ climb, loggers, ratings, comments }` for a known climb id.
- [ ] `GET /climbs/:id` returns 404 for an unknown id.
- [ ] Visit `/climbs/<id>` while logged in: card, ratings, loggers, comments all render.
- [ ] "Log this climb" adds the user to the loggers list and toasts success.
- [ ] Posting a comment / rating reflects optimistically (write endpoints land in a follow-up PR).